### PR TITLE
Add str to enums

### DIFF
--- a/src/sfapi_client/_models/__init__.py
+++ b/src/sfapi_client/_models/__init__.py
@@ -85,13 +85,13 @@ class Outage(BaseModel):
     update_at: Optional[datetime] = Field(None, title="Update At")
 
 
-class PublicHost(Enum):
+class PublicHost(str, Enum):
     cori = "cori"
     dtn01 = "dtn01"
     perlmutter = "perlmutter"
 
 
-class StatusValue(Enum):
+class StatusValue(str, Enum):
     active = "active"
     unavailable = "unavailable"
     degraded = "degraded"
@@ -141,7 +141,7 @@ class ValidationError(BaseModel):
     type: str = Field(..., title="Error Type")
 
 
-class AppRoutersComputeModelsStatus(Enum):
+class AppRoutersComputeModelsStatus(str, Enum):
     OK = "OK"
     ERROR = "ERROR"
 
@@ -156,12 +156,12 @@ class AppRoutersStatusModelsStatus(BaseModel):
     updated_at: Optional[datetime] = Field(None, title="Updated At")
 
 
-class AppRoutersStorageModelsStatus(Enum):
+class AppRoutersStorageModelsStatus(str, Enum):
     OK = "OK"
     ERROR = "ERROR"
 
 
-class AppRoutersUtilsModelsStatus(Enum):
+class AppRoutersUtilsModelsStatus(str, Enum):
     OK = "OK"
     ERROR = "ERROR"
 

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -9,7 +9,7 @@ from sfapi_client import Machines
 def test_compute(client_id, client_secret, test_machine):
     with Client(client_id, client_secret) as client:
         machine = client.compute(test_machine)
-
+        assert machine.status in ["active", "unavailable", "degraded", "other"]
         assert machine.name == test_machine.value
 
 

--- a/tests/test_compute_async.py
+++ b/tests/test_compute_async.py
@@ -10,7 +10,7 @@ from sfapi_client import Machines
 async def test_compute(client_id, client_secret, test_machine):
     async with AsyncClient(client_id, client_secret) as client:
         machine = await client.compute(test_machine)
-
+        assert machine.status in ["active", "unavailable", "degraded", "other"]
         assert machine.name == test_machine.value
 
 


### PR DESCRIPTION
Really simple change that adds str to the enums so that you can check based on the string name instead of just the object. `machine.status == 'active'`