### PR TITLE
Create client outside context manager

### DIFF
--- a/src/sfapi_client/_async/client.py
+++ b/src/sfapi_client/_async/client.py
@@ -86,8 +86,7 @@ class AsyncClient:
             await self.__oauth2_session.aclose()
 
     async def __aexit__(self, type, value, traceback):
-        if self.__oauth2_session is not None:
-            await self.__oauth2_session.aclose()
+        await self.close()
 
     def _read_client_secret_from_file(self, name):
         if name is not None and Path(name).exists():

--- a/src/sfapi_client/_sync/client.py
+++ b/src/sfapi_client/_sync/client.py
@@ -86,8 +86,7 @@ class Client:
             self.__oauth2_session.close()
 
     def __exit__(self, type, value, traceback):
-        if self.__oauth2_session is not None:
-            self.__oauth2_session.close()
+        self.close()
 
     def _read_client_secret_from_file(self, name):
         if name is not None and Path(name).exists():


### PR DESCRIPTION
Allows for creating a client outside of a context manager which could be helpful for things like jupyter notebooks.