### PR TITLE
Raise if the machine is unavailable for maintenance or down

### DIFF
--- a/src/sfapi_client/_async/compute.py
+++ b/src/sfapi_client/_async/compute.py
@@ -29,7 +29,7 @@ class AsyncCompute(ComputeBase):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         if self.status in [StatusValue.unavailable, StatusValue.other]:
-            raise SfApiError(f"Compute machine {self.name} is {self.status.name}, {self.notes}")
+            raise SfApiError(f"Compute resource {self.name} is {self.status.name}, {self.notes}")
         self._monitor = AsyncJobMonitor(self)
 
     def dict(self, *args, **kwargs) -> Dict:

--- a/src/sfapi_client/_sync/compute.py
+++ b/src/sfapi_client/_sync/compute.py
@@ -29,7 +29,7 @@ class Compute(ComputeBase):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         if self.status in [StatusValue.unavailable, StatusValue.other]:
-            raise SfApiError(f"Compute machine {self.name} is {self.status.name}, {self.notes}")
+            raise SfApiError(f"Compute resource {self.name} is {self.status.name}, {self.notes}")
         self._monitor = SyncJobMonitor(self)
 
     def dict(self, *args, **kwargs) -> Dict:


### PR DESCRIPTION
Realized today during the maintenance that the compute object will try to call other methods (`job`, `ls` etc.) even when it's unavailable. This will raise an error on creation if the machine is down so the user can handle it.