### PR TITLE
Mark tests that use public endpoints with "public"

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,12 +1,15 @@
+import pytest
 from sfapi_client import Client
 
 
+@pytest.mark.public
 def test_changelog():
     with Client() as client:
         changelog = client.api.changelog()
         assert len(changelog) > 0
 
 
+@pytest.mark.public
 def test_config():
     with Client() as client:
         config = client.api.config()

--- a/tests/test_api_async.py
+++ b/tests/test_api_async.py
@@ -3,6 +3,7 @@ import pytest
 from sfapi_client import AsyncClient
 
 
+@pytest.mark.public
 @pytest.mark.asyncio
 async def test_changelog():
     async with AsyncClient() as client:
@@ -10,6 +11,7 @@ async def test_changelog():
         assert len(changelog) > 0
 
 
+@pytest.mark.public
 @pytest.mark.asyncio
 async def test_config():
     async with AsyncClient() as client:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,12 +4,14 @@ import httpx
 from sfapi_client import AsyncClient
 
 
+@pytest.mark.public
 @pytest.mark.asyncio
 async def test_no_creds():
     async with AsyncClient() as client:
         assert client is not None
 
 
+@pytest.mark.public
 @pytest.mark.asyncio
 async def test_no_creds_auth_required(test_machine):
     async with AsyncClient() as client:

--- a/tests/test_client_async.py
+++ b/tests/test_client_async.py
@@ -4,12 +4,14 @@ import httpx
 from sfapi_client import AsyncClient
 
 
+@pytest.mark.public
 @pytest.mark.asyncio
 async def test_no_creds():
     async with AsyncClient() as client:
         assert client is not None
 
 
+@pytest.mark.public
 @pytest.mark.asyncio
 async def test_no_creds_auth_required(test_machine):
     async with AsyncClient() as client:

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,6 +1,8 @@
+import pytest
 from sfapi_client import Client
 
 
+@pytest.mark.public
 def test_outages_by_resource(test_machine):
     with Client() as client:
         outages = client.resources.outages(test_machine)
@@ -9,6 +11,7 @@ def test_outages_by_resource(test_machine):
         assert outages[0].name == test_machine
 
 
+@pytest.mark.public
 def test_planned_outages_by_resource(test_machine):
     with Client() as client:
         outages = client.resources.planned_outages(test_machine)
@@ -17,6 +20,7 @@ def test_planned_outages_by_resource(test_machine):
         assert outages[0].name == test_machine
 
 
+@pytest.mark.public
 def test_notes_by_resource(test_machine):
     with Client() as client:
         notes = client.resources.notes(test_machine)
@@ -25,6 +29,7 @@ def test_notes_by_resource(test_machine):
         assert notes[0].name == test_machine
 
 
+@pytest.mark.public
 def test_status_by_resource(test_machine):
     with Client() as client:
         status = client.resources.status(test_machine)
@@ -32,6 +37,7 @@ def test_status_by_resource(test_machine):
         assert status.name == test_machine
 
 
+@pytest.mark.public
 def test_outages(test_machine):
     with Client() as client:
         outages = client.resources.outages()
@@ -42,6 +48,7 @@ def test_outages(test_machine):
         assert test_machine_outages[0].name == test_machine
 
 
+@pytest.mark.public
 def test_planned_outages(test_machine):
     with Client() as client:
         outages = client.resources.planned_outages()
@@ -52,6 +59,7 @@ def test_planned_outages(test_machine):
         assert test_machine_outages[0].name == test_machine
 
 
+@pytest.mark.public
 def test_notes(test_machine):
     with Client() as client:
         notes = client.resources.notes()
@@ -62,6 +70,7 @@ def test_notes(test_machine):
         assert test_machine_notes[0].name == test_machine
 
 
+@pytest.mark.public
 def test_status(test_machine):
     with Client() as client:
         status = client.resources.status()

--- a/tests/test_resources_async.py
+++ b/tests/test_resources_async.py
@@ -2,7 +2,7 @@ import pytest
 
 from sfapi_client import AsyncClient
 
-
+@pytest.mark.public
 @pytest.mark.asyncio
 async def test_outages_by_resource(test_machine):
     async with AsyncClient() as client:
@@ -12,6 +12,7 @@ async def test_outages_by_resource(test_machine):
         assert outages[0].name == test_machine
 
 
+@pytest.mark.public
 @pytest.mark.asyncio
 async def test_planned_outages_by_resource(test_machine):
     async with AsyncClient() as client:
@@ -21,6 +22,7 @@ async def test_planned_outages_by_resource(test_machine):
         assert outages[0].name == test_machine
 
 
+@pytest.mark.public
 @pytest.mark.asyncio
 async def test_notes_by_resource(test_machine):
     async with AsyncClient() as client:
@@ -29,7 +31,7 @@ async def test_notes_by_resource(test_machine):
         assert len(notes) > 0
         assert notes[0].name == test_machine
 
-
+@pytest.mark.public
 @pytest.mark.asyncio
 async def test_status_by_resource(test_machine):
     async with AsyncClient() as client:
@@ -38,6 +40,7 @@ async def test_status_by_resource(test_machine):
         assert status.name == test_machine
 
 
+@pytest.mark.public
 @pytest.mark.asyncio
 async def test_outages(test_machine):
     async with AsyncClient() as client:
@@ -49,6 +52,7 @@ async def test_outages(test_machine):
         assert test_machine_outages[0].name == test_machine
 
 
+@pytest.mark.public
 @pytest.mark.asyncio
 async def test_planned_outages(test_machine):
     async with AsyncClient() as client:
@@ -59,7 +63,7 @@ async def test_planned_outages(test_machine):
         assert len(test_machine_outages) > 0
         assert test_machine_outages[0].name == test_machine
 
-
+@pytest.mark.public
 @pytest.mark.asyncio
 async def test_notes(test_machine):
     async with AsyncClient() as client:
@@ -70,7 +74,7 @@ async def test_notes(test_machine):
         assert len(test_machine_notes) > 0
         assert test_machine_notes[0].name == test_machine
 
-
+@pytest.mark.public
 @pytest.mark.asyncio
 async def test_status(test_machine):
     async with AsyncClient() as client:


### PR DESCRIPTION
This will allow use to run:

```console
$ pytest -m public
```

To run all the tests that don't need credentials.