### PR TITLE
Add mkdocs build step

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -23,4 +23,5 @@ jobs:
           restore-keys: |
             mkdocs-
       - run: pip install .[docs]
+      - run: mkdocs build
       - run: mkdocs gh-deploy --force


### PR DESCRIPTION
mkdocs gh-deploy should build before deploying, however, the auto generation of the sync documentation doesn't get called for some reason.