### PR TITLE
Allow ints as jobids

### DIFF
--- a/src/sfapi_client/_async/compute.py
+++ b/src/sfapi_client/_async/compute.py
@@ -121,7 +121,7 @@ class AsyncCompute(ComputeBase):
 
     @check_auth
     async def job(
-        self, jobid: int, command: Optional[JobCommand] = JobCommand.sacct
+        self, jobid: Union[int, str], command: Optional[JobCommand] = JobCommand.sacct
     ) -> Union["AsyncJobSacct", "AsyncJobSqueue"]:
         # Get different job depending on query
         Job = AsyncJobSacct if (command == JobCommand.sacct) else AsyncJobSqueue
@@ -134,7 +134,7 @@ class AsyncCompute(ComputeBase):
     @check_auth
     async def jobs(
         self,
-        jobids: Optional[int] = None,
+        jobids: Optional[Union[List[int], List[str]]] = None,
         user: Optional[str] = None,
         partition: Optional[str] = None,
         command: Optional[JobCommand] = JobCommand.squeue,

--- a/src/sfapi_client/_async/compute.py
+++ b/src/sfapi_client/_async/compute.py
@@ -134,7 +134,7 @@ class AsyncCompute(ComputeBase):
     @check_auth
     async def jobs(
         self,
-        jobids: Optional[Union[List[int], List[str]]] = None,
+        jobids: Optional[List[Union[int, str]]] = None,
         user: Optional[str] = None,
         partition: Optional[str] = None,
         command: Optional[JobCommand] = JobCommand.squeue,

--- a/src/sfapi_client/_monitor.py
+++ b/src/sfapi_client/_monitor.py
@@ -62,7 +62,7 @@ class AsyncJobMonitor:
         return job_type
 
     async def fetch_jobs(
-        self, job_type: Union[AsyncJobSacct, AsyncJobSqueue], jobids: Union[List[int], List[str]]
+        self, job_type: Union[AsyncJobSacct, AsyncJobSqueue], jobids: List[Union[int, str]]
     ) -> List[Union[AsyncJobSacct, AsyncJobSqueue]]:
         jobids = list(map(str, jobids))
         jobids_for_type = self._jobids.setdefault(job_type, set())
@@ -133,7 +133,7 @@ class SyncJobMonitor:
         self._request_lock = Lock()
 
     def fetch_jobs(
-        self, job_type: Union["JobSacct", "JobSqueue"], jobids: Union[List[int], List[str]]
+        self, job_type: Union["JobSacct", "JobSqueue"], jobids: List[Union[int, str]]
     ) -> List[Union[JobSqueue, JobSacct]]:
         jobids = list(map(str, jobids))
         # First update the jobids and create a request context

--- a/src/sfapi_client/_monitor.py
+++ b/src/sfapi_client/_monitor.py
@@ -62,8 +62,9 @@ class AsyncJobMonitor:
         return job_type
 
     async def fetch_jobs(
-        self, job_type: Union[AsyncJobSacct, AsyncJobSqueue], jobids: List[int]
+        self, job_type: Union[AsyncJobSacct, AsyncJobSqueue], jobids: Union[List[int], List[str]]
     ) -> List[Union[AsyncJobSacct, AsyncJobSqueue]]:
+        jobids = list(map(str, jobids))
         jobids_for_type = self._jobids.setdefault(job_type, set())
         jobids_for_type.update(jobids)
 
@@ -132,8 +133,9 @@ class SyncJobMonitor:
         self._request_lock = Lock()
 
     def fetch_jobs(
-        self, job_type: Union["JobSacct", "JobSqueue"], jobids: List[int]
+        self, job_type: Union["JobSacct", "JobSqueue"], jobids: Union[List[int], List[str]]
     ) -> List[Union[JobSqueue, JobSacct]]:
+        jobids = list(map(str, jobids))
         # First update the jobids and create a request context
         request = None
         with self._requests_lock:

--- a/src/sfapi_client/_sync/compute.py
+++ b/src/sfapi_client/_sync/compute.py
@@ -121,7 +121,7 @@ class Compute(ComputeBase):
 
     @check_auth
     def job(
-        self, jobid: int, command: Optional[JobCommand] = JobCommand.sacct
+        self, jobid: Union[int, str], command: Optional[JobCommand] = JobCommand.sacct
     ) -> Union["JobSacct", "JobSqueue"]:
         # Get different job depending on query
         Job = JobSacct if (command == JobCommand.sacct) else JobSqueue
@@ -134,7 +134,7 @@ class Compute(ComputeBase):
     @check_auth
     def jobs(
         self,
-        jobids: Optional[int] = None,
+        jobids: Optional[Union[List[int], List[str]]] = None,
         user: Optional[str] = None,
         partition: Optional[str] = None,
         command: Optional[JobCommand] = JobCommand.squeue,

--- a/src/sfapi_client/_sync/compute.py
+++ b/src/sfapi_client/_sync/compute.py
@@ -134,7 +134,7 @@ class Compute(ComputeBase):
     @check_auth
     def jobs(
         self,
-        jobids: Optional[Union[List[int], List[str]]] = None,
+        jobids: Optional[List[Union[int, str]]] = None,
         user: Optional[str] = None,
         partition: Optional[str] = None,
         command: Optional[JobCommand] = JobCommand.squeue,


### PR DESCRIPTION
Currently there's a bug if you try to use int's as jobids. This just converts all the `int`s to `str`s before fetching the jobs. I updated the typing as well.