### PR TITLE
Allow api url and token url to be configured

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,12 +8,15 @@ from authlib.jose import JsonWebKey
 
 from sfapi_client.compute import Machine
 from sfapi_client import Resource
+from sfapi_client import Client, AsyncClient
 
 from pydantic import ConfigDict
 from pydantic_settings import BaseSettings
 
 
 class Settings(BaseSettings):
+    API_BASE_URL: str = "https://api.nersc.gov/api/v1.2"
+    TOKEN_URL: str = "https://oidc.nersc.gov/c2id/token"
     SFAPI_CLIENT_ID: Optional[str] = None
     SFAPI_CLIENT_SECRET: Optional[Union[str, Dict]] = None
     SFAPI_DEV_CLIENT_ID: Optional[str] = None
@@ -125,3 +128,43 @@ def dev_api_url():
 @pytest.fixture
 def dev_token_url():
     return settings.DEV_TOKEN_URL
+
+
+@pytest.fixture
+def api_base_url():
+    return settings.API_BASE_URL
+
+
+@pytest.fixture
+def token_url():
+    return settings.TOKEN_URL
+
+
+@pytest.fixture
+def unauthenticated_client(api_base_url):
+    return Client(api_base_url=api_base_url)
+
+
+@pytest.fixture
+def async_unauthenticated_client(api_base_url):
+    return AsyncClient(api_base_url=api_base_url)
+
+
+@pytest.fixture
+def authenticated_client(api_base_url, token_url, client_id, client_secret):
+    return Client(
+        api_base_url=api_base_url,
+        token_url=token_url,
+        client_id=client_id,
+        secret=client_secret,
+    )
+
+
+@pytest.fixture
+def async_authenticated_client(api_base_url, token_url, client_id, client_secret):
+    return AsyncClient(
+        api_base_url=api_base_url,
+        token_url=token_url,
+        client_id=client_id,
+        secret=client_secret,
+    )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,16 +1,15 @@
 import pytest
-from sfapi_client import Client
 
 
 @pytest.mark.public
-def test_changelog():
-    with Client() as client:
+def test_changelog(unauthenticated_client):
+    with unauthenticated_client as client:
         changelog = client.api.changelog()
         assert len(changelog) > 0
 
 
 @pytest.mark.public
-def test_config():
-    with Client() as client:
+def test_config(unauthenticated_client):
+    with unauthenticated_client as client:
         config = client.api.config()
         assert "compute.targets" in config

--- a/tests/test_api_async.py
+++ b/tests/test_api_async.py
@@ -1,19 +1,17 @@
 import pytest
 
-from sfapi_client import AsyncClient
-
 
 @pytest.mark.public
 @pytest.mark.asyncio
-async def test_changelog():
-    async with AsyncClient() as client:
+async def test_changelog(async_unauthenticated_client):
+    async with async_unauthenticated_client as client:
         changelog = await client.api.changelog()
         assert len(changelog) > 0
 
 
 @pytest.mark.public
 @pytest.mark.asyncio
-async def test_config():
-    async with AsyncClient() as client:
+async def test_config(async_unauthenticated_client):
+    async with async_unauthenticated_client as client:
         config = await client.api.config()
         assert "compute.targets" in config

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,17 +1,17 @@
 import pytest
 
-from sfapi_client import Client, SfApiError
+from sfapi_client import SfApiError
 
 
 @pytest.mark.public
-def test_no_creds():
-    with Client() as client:
+def test_no_creds(unauthenticated_client):
+    with unauthenticated_client as client:
         assert client is not None
 
 
 @pytest.mark.public
-def test_no_creds_auth_required(test_machine):
-    with Client() as client:
+def test_no_creds_auth_required(unauthenticated_client, test_machine):
+    with unauthenticated_client as client:
         machine = client.compute(test_machine)
         with pytest.raises(SfApiError):
             machine.jobs()

--- a/tests/test_client_async.py
+++ b/tests/test_client_async.py
@@ -1,19 +1,19 @@
 import pytest
 
-from sfapi_client import AsyncClient, SfApiError
+from sfapi_client import SfApiError
 
 
 @pytest.mark.public
 @pytest.mark.asyncio
-async def test_no_creds():
-    async with AsyncClient() as client:
+async def test_no_creds(async_unauthenticated_client):
+    async with async_unauthenticated_client as client:
         assert client is not None
 
 
 @pytest.mark.public
 @pytest.mark.asyncio
-async def test_no_creds_auth_required(test_machine):
-    async with AsyncClient() as client:
+async def test_no_creds_auth_required(async_unauthenticated_client, test_machine):
+    async with async_unauthenticated_client as client:
         machine = await client.compute(test_machine)
         with pytest.raises(SfApiError):
             await machine.jobs()

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -1,18 +1,17 @@
 from pathlib import Path
 
-from sfapi_client import Client
 from sfapi_client.jobs import JobState
 
 
-def test_compute(client_id, client_secret, test_machine):
-    with Client(client_id, client_secret) as client:
+def test_compute(authenticated_client, test_machine):
+    with authenticated_client as client:
         machine = client.compute(test_machine)
         assert machine.status in ["active", "unavailable", "degraded", "other"]
         assert machine.name == test_machine.value
 
 
-def test_job(client_id, client_secret, test_job_path, test_machine):
-    with Client(client_id, client_secret) as client:
+def test_job(authenticated_client, test_job_path, test_machine):
+    with authenticated_client as client:
         machine = client.compute(test_machine)
 
         job = machine.submit_job(test_job_path)
@@ -24,14 +23,14 @@ def test_job(client_id, client_secret, test_job_path, test_machine):
         assert job.jobid == job_looked_up.jobid
 
 
-def test_fetch_jobs(client_id, client_secret, test_machine, test_username):
-    with Client(client_id, client_secret) as client:
+def test_fetch_jobs(authenticated_client, test_machine, test_username):
+    with authenticated_client as client:
         machine = client.compute(test_machine)
         machine.jobs(user=test_username)
 
 
-def test_list_dir_contents(client_id, client_secret, test_machine, test_job_path):
-    with Client(client_id, client_secret) as client:
+def test_list_dir_contents(authenticated_client, test_machine, test_job_path):
+    with authenticated_client as client:
         machine = client.compute(test_machine)
         test_job = Path(test_job_path)
         test_path = test_job.parent
@@ -48,8 +47,8 @@ def test_list_dir_contents(client_id, client_secret, test_machine, test_job_path
         assert found
 
 
-def test_list_dir(client_id, client_secret, test_machine, test_job_path):
-    with Client(client_id, client_secret) as client:
+def test_list_dir(authenticated_client, test_machine, test_job_path):
+    with authenticated_client as client:
         machine = client.compute(test_machine)
         test_job = Path(test_job_path)
         test_path = test_job.parent
@@ -59,8 +58,8 @@ def test_list_dir(client_id, client_secret, test_machine, test_job_path):
         assert paths[0].name == test_path.name
 
 
-def test_list_file(client_id, client_secret, test_machine, test_job_path):
-    with Client(client_id, client_secret) as client:
+def test_list_file(authenticated_client, test_machine, test_job_path):
+    with authenticated_client as client:
         machine = client.compute(test_machine)
         test_job_filename = Path(test_job_path).name
 
@@ -75,24 +74,24 @@ def test_list_file(client_id, client_secret, test_machine, test_job_path):
         assert found
 
 
-def test_run_arg_list(client_id, client_secret, test_machine, test_job_path):
-    with Client(client_id, client_secret) as client:
+def test_run_arg_list(authenticated_client, test_machine, test_job_path):
+    with authenticated_client as client:
         machine = client.compute(test_machine)
         output = machine.run(["ls", test_job_path])
 
         assert test_job_path in output
 
 
-def test_run_arg_str(client_id, client_secret, test_machine, test_job_path):
-    with Client(client_id, client_secret) as client:
+def test_run_arg_str(authenticated_client, test_machine, test_job_path):
+    with authenticated_client as client:
         machine = client.compute(test_machine)
         output = machine.run(f"ls {test_job_path}")
 
         assert test_job_path in output
 
 
-def test_run_arg_path(client_id, client_secret, test_machine):
-    with Client(client_id, client_secret) as client:
+def test_run_arg_path(authenticated_client, test_machine):
+    with authenticated_client as client:
         machine = client.compute(test_machine)
         [remote_path] = machine.ls("/usr/bin/hostname")
         output = machine.run(remote_path)

--- a/tests/test_compute_async.py
+++ b/tests/test_compute_async.py
@@ -1,21 +1,20 @@
 import pytest
 from pathlib import Path
 
-from sfapi_client import AsyncClient
 from sfapi_client.jobs import JobState
 
 
 @pytest.mark.asyncio
-async def test_compute(client_id, client_secret, test_machine):
-    async with AsyncClient(client_id, client_secret) as client:
+async def test_compute(async_authenticated_client, test_machine):
+    async with async_authenticated_client as client:
         machine = await client.compute(test_machine)
         assert machine.status in ["active", "unavailable", "degraded", "other"]
         assert machine.name == test_machine.value
 
 
 @pytest.mark.asyncio
-async def test_job(client_id, client_secret, test_job_path, test_machine):
-    async with AsyncClient(client_id, client_secret) as client:
+async def test_job(async_authenticated_client, test_job_path, test_machine):
+    async with async_authenticated_client as client:
         machine = await client.compute(test_machine)
 
         job = await machine.submit_job(test_job_path)
@@ -28,15 +27,17 @@ async def test_job(client_id, client_secret, test_job_path, test_machine):
 
 
 @pytest.mark.asyncio
-async def test_fetch_jobs(client_id, client_secret, test_machine, test_username):
-    async with AsyncClient(client_id, client_secret) as client:
+async def test_fetch_jobs(async_authenticated_client, test_machine, test_username):
+    async with async_authenticated_client as client:
         machine = await client.compute(test_machine)
         await machine.jobs(user=test_username)
 
 
 @pytest.mark.asyncio
-async def test_list_dir_contents(client_id, client_secret, test_machine, test_job_path):
-    async with AsyncClient(client_id, client_secret) as client:
+async def test_list_dir_contents(
+    async_authenticated_client, test_machine, test_job_path
+):
+    async with async_authenticated_client as client:
         machine = await client.compute(test_machine)
         test_job = Path(test_job_path)
         test_path = test_job.parent
@@ -54,8 +55,8 @@ async def test_list_dir_contents(client_id, client_secret, test_machine, test_jo
 
 
 @pytest.mark.asyncio
-async def test_list_dir(client_id, client_secret, test_machine, test_job_path):
-    async with AsyncClient(client_id, client_secret) as client:
+async def test_list_dir(async_authenticated_client, test_machine, test_job_path):
+    async with async_authenticated_client as client:
         machine = await client.compute(test_machine)
         test_job = Path(test_job_path)
         test_path = test_job.parent
@@ -66,8 +67,8 @@ async def test_list_dir(client_id, client_secret, test_machine, test_job_path):
 
 
 @pytest.mark.asyncio
-async def test_list_file(client_id, client_secret, test_machine, test_job_path):
-    async with AsyncClient(client_id, client_secret) as client:
+async def test_list_file(async_authenticated_client, test_machine, test_job_path):
+    async with async_authenticated_client as client:
         machine = await client.compute(test_machine)
         test_job_filename = Path(test_job_path).name
         test_job_dir = Path(test_job_path).parent
@@ -84,8 +85,8 @@ async def test_list_file(client_id, client_secret, test_machine, test_job_path):
 
 
 @pytest.mark.asyncio
-async def test_run_arg_list(client_id, client_secret, test_machine, test_job_path):
-    async with AsyncClient(client_id, client_secret) as client:
+async def test_run_arg_list(async_authenticated_client, test_machine, test_job_path):
+    async with async_authenticated_client as client:
         machine = await client.compute(test_machine)
         output = await machine.run(["ls", test_job_path])
 
@@ -93,8 +94,8 @@ async def test_run_arg_list(client_id, client_secret, test_machine, test_job_pat
 
 
 @pytest.mark.asyncio
-async def test_run_arg_str(client_id, client_secret, test_machine, test_job_path):
-    async with AsyncClient(client_id, client_secret) as client:
+async def test_run_arg_str(async_authenticated_client, test_machine, test_job_path):
+    async with async_authenticated_client as client:
         machine = await client.compute(test_machine)
         output = await machine.run(f"ls {test_job_path}")
 
@@ -102,8 +103,8 @@ async def test_run_arg_str(client_id, client_secret, test_machine, test_job_path
 
 
 @pytest.mark.asyncio
-async def test_run_arg_path(client_id, client_secret, test_machine):
-    async with AsyncClient(client_id, client_secret) as client:
+async def test_run_arg_path(async_authenticated_client, test_machine):
+    async with async_authenticated_client as client:
         machine = await client.compute(test_machine)
         [remote_path] = await machine.ls("/usr/bin/hostname")
         output = await machine.run(remote_path)
@@ -112,8 +113,8 @@ async def test_run_arg_path(client_id, client_secret, test_machine):
 
 
 @pytest.mark.asyncio
-async def test_outages(client_id, client_secret, test_machine):
-    async with AsyncClient(client_id, client_secret) as client:
+async def test_outages(async_authenticated_client, test_machine):
+    async with async_authenticated_client as client:
         machine = await client.compute(test_machine)
         outages = await machine.outages()
 
@@ -121,8 +122,8 @@ async def test_outages(client_id, client_secret, test_machine):
 
 
 @pytest.mark.asyncio
-async def test_planned_outages(client_id, client_secret, test_machine):
-    async with AsyncClient(client_id, client_secret) as client:
+async def test_planned_outages(async_authenticated_client, test_machine):
+    async with async_authenticated_client as client:
         machine = await client.compute(test_machine)
         outages = await machine.planned_outages()
 

--- a/tests/test_groups_async.py
+++ b/tests/test_groups_async.py
@@ -4,11 +4,8 @@ from sfapi_client import AsyncClient
 
 
 @pytest.mark.asyncio
-async def test_group(client_id, client_secret, test_group):
-    async with AsyncClient(
-        client_id=client_id,
-        secret=client_secret,
-    ) as client:
+async def test_group(async_authenticated_client, test_group):
+    async with async_authenticated_client as client:
         group = await client.group(test_group)
         assert group is not None
         assert group.name == test_group

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -8,8 +8,8 @@ from sfapi_client.compute import Compute
 from sfapi_client.jobs import JobSqueue
 
 
-def test_submit(client_id, client_secret, test_job_path, test_machine):
-    with Client(client_id, client_secret) as client:
+def test_submit(authenticated_client, test_job_path, test_machine):
+    with authenticated_client as client:
         machine = client.compute(test_machine)
         job = machine.submit_job(test_job_path)
 
@@ -18,23 +18,23 @@ def test_submit(client_id, client_secret, test_job_path, test_machine):
         assert state == JobState.COMPLETED
 
 
-def test_cancel(client_id, client_secret, test_job_path, test_machine):
-    with Client(client_id, client_secret) as client:
+def test_cancel(authenticated_client, test_job_path, test_machine):
+    with authenticated_client as client:
         machine = client.compute(test_machine)
         job = machine.submit_job(test_job_path)
 
         job.cancel()
 
 
-def test_cancel_wait_for_it(client_id, client_secret, test_job_path, test_machine):
-    with Client(client_id, client_secret) as client:
+def test_cancel_wait_for_it(authenticated_client, test_job_path, test_machine):
+    with authenticated_client as client:
         machine = client.compute(test_machine)
         job = machine.submit_job(test_job_path)
         job.cancel(wait=True)
 
 
-def test_running(client_id, client_secret, test_job_path, test_machine):
-    with Client(client_id, client_secret, wait_interval=1) as client:
+def test_running(authenticated_client, test_job_path, test_machine):
+    with authenticated_client as client:
         machine = client.compute(test_machine)
         job = machine.submit_job(test_job_path)
 
@@ -43,8 +43,8 @@ def test_running(client_id, client_secret, test_job_path, test_machine):
         assert state == JobState.RUNNING
 
 
-def test_complete_timeout(client_id, client_secret, test_job_path, test_machine):
-    with Client(client_id, client_secret) as client:
+def test_complete_timeout(authenticated_client, test_job_path, test_machine):
+    with authenticated_client as client:
         machine = client.compute(test_machine)
         job = machine.submit_job(test_job_path)
 

--- a/tests/test_jobs_async.py
+++ b/tests/test_jobs_async.py
@@ -7,8 +7,8 @@ from sfapi_client.jobs import AsyncJobSqueue, AsyncJobSacct, JobState
 
 
 @pytest.mark.asyncio
-async def test_submit(client_id, client_secret, test_job_path, test_machine):
-    async with AsyncClient(client_id, client_secret) as client:
+async def test_submit(async_authenticated_client, test_job_path, test_machine):
+    async with async_authenticated_client as client:
         machine = await client.compute(test_machine)
         job = await machine.submit_job(test_job_path)
 
@@ -18,8 +18,8 @@ async def test_submit(client_id, client_secret, test_job_path, test_machine):
 
 
 @pytest.mark.asyncio
-async def test_cancel(client_id, client_secret, test_job_path, test_machine):
-    async with AsyncClient(client_id, client_secret) as client:
+async def test_cancel(async_authenticated_client, test_job_path, test_machine):
+    async with async_authenticated_client as client:
         machine = await client.compute(test_machine)
         job = await machine.submit_job(test_job_path)
 
@@ -28,9 +28,9 @@ async def test_cancel(client_id, client_secret, test_job_path, test_machine):
 
 @pytest.mark.asyncio
 async def test_cancel_wait_for_it(
-    client_id, client_secret, test_job_path, test_machine
+    async_authenticated_client, test_job_path, test_machine
 ):
-    async with AsyncClient(client_id, client_secret) as client:
+    async with async_authenticated_client as client:
         machine = await client.compute(test_machine)
         job = await machine.submit_job(test_job_path)
 
@@ -40,8 +40,8 @@ async def test_cancel_wait_for_it(
 
 
 @pytest.mark.asyncio
-async def test_running(client_id, client_secret, test_job_path, test_machine):
-    async with AsyncClient(client_id, client_secret, wait_interval=1) as client:
+async def test_running(async_authenticated_client, test_job_path, test_machine):
+    async with async_authenticated_client as client:
         machine = await client.compute(test_machine)
         job = await machine.submit_job(test_job_path)
 
@@ -51,8 +51,10 @@ async def test_running(client_id, client_secret, test_job_path, test_machine):
 
 
 @pytest.mark.asyncio
-async def test_complete_timeout(client_id, client_secret, test_job_path, test_machine):
-    async with AsyncClient(client_id, client_secret, wait_interval=1) as client:
+async def test_complete_timeout(
+    async_authenticated_client, test_job_path, test_machine
+):
+    async with async_authenticated_client as client:
         machine = await client.compute(test_machine)
         job = await machine.submit_job(test_job_path)
 
@@ -62,9 +64,9 @@ async def test_complete_timeout(client_id, client_secret, test_job_path, test_ma
 
 @pytest.mark.asyncio
 async def test_job_monitor_check_request(
-    mocker, client_id, client_secret, test_job_path, test_machine
+    async_authenticated_client, mocker, test_job_path, test_machine
 ):
-    async with AsyncClient(client_id, client_secret) as client:
+    async with async_authenticated_client as client:
         _fetch_jobs_async = mocker.patch("sfapi_client._monitor._fetch_jobs_async")
         machine = await client.compute(test_machine)
 
@@ -107,10 +109,8 @@ async def test_job_monitor_check_request(
 
 
 @pytest.mark.asyncio
-async def test_job_monitor_job_types(
-    mocker, client_id, client_secret, test_job_path, test_machine
-):
-    async with AsyncClient(client_id, client_secret) as client:
+async def test_job_monitor_job_types(async_authenticated_client, mocker, test_machine):
+    async with async_authenticated_client as client:
         _fetch_jobs_async = mocker.patch("sfapi_client._monitor._fetch_jobs_async")
         machine = await client.compute(test_machine)
 

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -4,7 +4,6 @@ from io import BytesIO
 import random
 import string
 
-from sfapi_client import Client
 from sfapi_client.paths import RemotePath
 
 
@@ -33,8 +32,8 @@ def test_parent():
         assert isinstance(p, RemotePath)
 
 
-def test_download_text(client_id, client_secret, test_machine, test_job_path):
-    with Client(client_id, client_secret) as client:
+def test_download_text(authenticated_client, test_machine, test_job_path):
+    with authenticated_client as client:
         machine = client.compute(test_machine)
         test_job = Path(test_job_path)
         test_path = test_job.parent
@@ -55,8 +54,8 @@ def test_download_text(client_id, client_secret, test_machine, test_job_path):
         assert "#SBATCH" in contents
 
 
-def test_download_binary(client_id, client_secret, test_machine, test_job_path):
-    with Client(client_id, client_secret) as client:
+def test_download_binary(authenticated_client, test_machine, test_job_path):
+    with authenticated_client as client:
         machine = client.compute(test_machine)
         test_job = Path(test_job_path)
         test_path = test_job.parent
@@ -77,8 +76,8 @@ def test_download_binary(client_id, client_secret, test_machine, test_job_path):
         assert "#SBATCH" in bytes.decode()
 
 
-def test_ls_dir(client_id, client_secret, test_machine, test_job_path, test_username):
-    with Client(client_id, client_secret) as client:
+def test_ls_dir(authenticated_client, test_machine, test_job_path, test_username):
+    with authenticated_client as client:
         machine = client.compute(test_machine)
         test_job = Path(test_job_path)
         test_job_directory_name = test_job.parent.name
@@ -106,8 +105,8 @@ def test_ls_dir(client_id, client_secret, test_machine, test_job_path, test_user
         assert found
 
 
-def test_upload_file_to_directory(client_id, client_secret, test_machine, test_tmp_dir):
-    with Client(client_id, client_secret) as client:
+def test_upload_file_to_directory(authenticated_client, test_machine, test_tmp_dir):
+    with authenticated_client as client:
         machine = client.compute(test_machine)
 
         paths = machine.ls(test_tmp_dir, directory=True)
@@ -122,8 +121,8 @@ def test_upload_file_to_directory(client_id, client_secret, test_machine, test_t
         assert remote_file.download().read() == file_contents
 
 
-def test_upload_file_to_file(client_id, client_secret, test_machine, test_tmp_dir):
-    with Client(client_id, client_secret) as client:
+def test_upload_file_to_file(authenticated_client, test_machine, test_tmp_dir):
+    with authenticated_client as client:
         machine = client.compute(test_machine)
 
         paths = machine.ls(test_tmp_dir, directory=True)
@@ -142,8 +141,8 @@ def test_upload_file_to_file(client_id, client_secret, test_machine, test_tmp_di
         assert remote_file.download().read() == file_contents
 
 
-def test_file_open_invalid_mode(client_id, client_secret, test_machine, test_job_path):
-    with Client(client_id, client_secret) as client:
+def test_file_open_invalid_mode(authenticated_client, test_machine, test_job_path):
+    with authenticated_client as client:
         machine = client.compute(test_machine)
         [test_job_remote_path] = machine.ls(test_job_path)
 
@@ -164,8 +163,8 @@ def test_file_open_invalid_mode(client_id, client_secret, test_machine, test_job
                 pass
 
 
-def test_file_open_read_text(client_id, client_secret, test_machine, test_job_path):
-    with Client(client_id, client_secret) as client:
+def test_file_open_read_text(authenticated_client, test_machine, test_job_path):
+    with authenticated_client as client:
         machine = client.compute(test_machine)
         test_job_remote_path = machine.ls(test_job_path)
         assert len(test_job_remote_path) == 1
@@ -176,8 +175,8 @@ def test_file_open_read_text(client_id, client_secret, test_machine, test_job_pa
             assert "#SBATCH" in contents
 
 
-def test_file_open_read_binary(client_id, client_secret, test_machine, test_job_path):
-    with Client(client_id, client_secret) as client:
+def test_file_open_read_binary(authenticated_client, test_machine, test_job_path):
+    with authenticated_client as client:
         machine = client.compute(test_machine)
         test_job_remote_path = machine.ls(test_job_path)
         assert len(test_job_remote_path) == 1
@@ -188,8 +187,8 @@ def test_file_open_read_binary(client_id, client_secret, test_machine, test_job_
             assert "#SBATCH" in contents
 
 
-def test_file_open_write_text(client_id, client_secret, test_machine, test_tmp_dir):
-    with Client(client_id, client_secret) as client:
+def test_file_open_write_text(authenticated_client, test_machine, test_tmp_dir):
+    with authenticated_client as client:
         machine = client.compute(test_machine)
         remote_tmp_dir = machine.ls(test_tmp_dir, directory=True)
         assert len(remote_tmp_dir) == 1
@@ -210,8 +209,8 @@ def test_file_open_write_text(client_id, client_secret, test_machine, test_tmp_d
             assert file_contents in fp.read()
 
 
-def test_file_open_write_binary(client_id, client_secret, test_machine, test_tmp_dir):
-    with Client(client_id, client_secret) as client:
+def test_file_open_write_binary(authenticated_client, test_machine, test_tmp_dir):
+    with authenticated_client as client:
         machine = client.compute(test_machine)
         remote_tmp_dir = machine.ls(test_tmp_dir, directory=True)
         assert len(remote_tmp_dir) == 1
@@ -232,8 +231,8 @@ def test_file_open_write_binary(client_id, client_secret, test_machine, test_tmp
             assert file_contents in fp.read()
 
 
-def test_file_open_write_new(client_id, client_secret, test_machine, test_tmp_dir):
-    with Client(client_id, client_secret) as client:
+def test_file_open_write_new(authenticated_client, test_machine, test_tmp_dir):
+    with authenticated_client as client:
         machine = client.compute(test_machine)
         remote_tmp_dir = machine.ls(test_tmp_dir, directory=True)
         assert len(remote_tmp_dir) == 1

--- a/tests/test_paths_async.py
+++ b/tests/test_paths_async.py
@@ -4,12 +4,10 @@ from io import BytesIO
 import random
 import string
 
-from sfapi_client import AsyncClient
-
 
 @pytest.mark.asyncio
-async def test_download_text(client_id, client_secret, test_machine, test_job_path):
-    async with AsyncClient(client_id, client_secret) as client:
+async def test_download_text(async_authenticated_client, test_machine, test_job_path):
+    async with async_authenticated_client as client:
         machine = await client.compute(test_machine)
         test_job = Path(test_job_path)
         test_path = test_job.parent
@@ -31,8 +29,8 @@ async def test_download_text(client_id, client_secret, test_machine, test_job_pa
 
 
 @pytest.mark.asyncio
-async def test_download_binary(client_id, client_secret, test_machine, test_job_path):
-    async with AsyncClient(client_id, client_secret) as client:
+async def test_download_binary(async_authenticated_client, test_machine, test_job_path):
+    async with async_authenticated_client as client:
         machine = await client.compute(test_machine)
         test_job = Path(test_job_path)
         test_path = test_job.parent
@@ -55,9 +53,9 @@ async def test_download_binary(client_id, client_secret, test_machine, test_job_
 
 @pytest.mark.asyncio
 async def test_download_directory(
-    client_id, client_secret, test_machine, test_job_path
+    async_authenticated_client, test_machine, test_job_path
 ):
-    async with AsyncClient(client_id, client_secret) as client:
+    async with async_authenticated_client as client:
         machine = await client.compute(test_machine)
         test_job = Path(test_job_path)
         test_path = test_job.parent.parent
@@ -76,9 +74,9 @@ async def test_download_directory(
 
 @pytest.mark.asyncio
 async def test_ls_dir(
-    client_id, client_secret, test_machine, test_job_path, test_username
+    async_authenticated_client, test_machine, test_job_path, test_username
 ):
-    async with AsyncClient(client_id, client_secret) as client:
+    async with async_authenticated_client as client:
         machine = await client.compute(test_machine)
         test_job = Path(test_job_path)
         test_job_directory_name = test_job.parent.name
@@ -107,8 +105,10 @@ async def test_ls_dir(
 
 
 @pytest.mark.asyncio
-async def test_ls_excludes_dots(client_id, client_secret, test_machine, test_job_path):
-    async with AsyncClient(client_id, client_secret) as client:
+async def test_ls_excludes_dots(
+    async_authenticated_client, test_machine, test_job_path
+):
+    async with async_authenticated_client as client:
         machine = await client.compute(test_machine)
         test_job = Path(test_job_path)
         test_job_directory = test_job.parent
@@ -126,9 +126,9 @@ async def test_ls_excludes_dots(client_id, client_secret, test_machine, test_job
 
 @pytest.mark.asyncio
 async def test_upload_file_to_directory(
-    client_id, client_secret, test_machine, test_tmp_dir
+    async_authenticated_client, test_machine, test_tmp_dir
 ):
-    async with AsyncClient(client_id, client_secret) as client:
+    async with async_authenticated_client as client:
         machine = await client.compute(test_machine)
 
         paths = await machine.ls(test_tmp_dir, directory=True)
@@ -145,9 +145,9 @@ async def test_upload_file_to_directory(
 
 @pytest.mark.asyncio
 async def test_upload_file_to_file(
-    client_id, client_secret, test_machine, test_tmp_dir
+    async_authenticated_client, test_machine, test_tmp_dir
 ):
-    async with AsyncClient(client_id, client_secret) as client:
+    async with async_authenticated_client as client:
         machine = await client.compute(test_machine)
 
         paths = await machine.ls(test_tmp_dir, directory=True)
@@ -168,9 +168,9 @@ async def test_upload_file_to_file(
 
 @pytest.mark.asyncio
 async def test_file_open_invalid_mode(
-    client_id, client_secret, test_machine, test_job_path
+    async_authenticated_client, test_machine, test_job_path
 ):
-    async with AsyncClient(client_id, client_secret) as client:
+    async with async_authenticated_client as client:
         machine = await client.compute(test_machine)
         [test_job_remote_path] = await machine.ls(test_job_path)
 
@@ -193,9 +193,9 @@ async def test_file_open_invalid_mode(
 
 @pytest.mark.asyncio
 async def test_file_open_read_text(
-    client_id, client_secret, test_machine, test_job_path
+    async_authenticated_client, test_machine, test_job_path
 ):
-    async with AsyncClient(client_id, client_secret) as client:
+    async with async_authenticated_client as client:
         machine = await client.compute(test_machine)
         test_job_remote_path = await machine.ls(test_job_path)
         assert len(test_job_remote_path) == 1
@@ -208,9 +208,9 @@ async def test_file_open_read_text(
 
 @pytest.mark.asyncio
 async def test_file_open_read_binary(
-    client_id, client_secret, test_machine, test_job_path
+    async_authenticated_client, test_machine, test_job_path
 ):
-    async with AsyncClient(client_id, client_secret) as client:
+    async with async_authenticated_client as client:
         machine = await client.compute(test_machine)
         test_job_remote_path = await machine.ls(test_job_path)
         assert len(test_job_remote_path) == 1
@@ -223,9 +223,9 @@ async def test_file_open_read_binary(
 
 @pytest.mark.asyncio
 async def test_file_open_write_text(
-    client_id, client_secret, test_machine, test_tmp_dir
+    async_authenticated_client, test_machine, test_tmp_dir
 ):
-    async with AsyncClient(client_id, client_secret) as client:
+    async with async_authenticated_client as client:
         machine = await client.compute(test_machine)
         remote_tmp_dir = await machine.ls(test_tmp_dir, directory=True)
         assert len(remote_tmp_dir) == 1
@@ -248,9 +248,9 @@ async def test_file_open_write_text(
 
 @pytest.mark.asyncio
 async def test_file_open_write_binary(
-    client_id, client_secret, test_machine, test_tmp_dir
+    async_authenticated_client, test_machine, test_tmp_dir
 ):
-    async with AsyncClient(client_id, client_secret) as client:
+    async with async_authenticated_client as client:
         machine = await client.compute(test_machine)
         remote_tmp_dir = await machine.ls(test_tmp_dir, directory=True)
         assert len(remote_tmp_dir) == 1
@@ -273,9 +273,9 @@ async def test_file_open_write_binary(
 
 @pytest.mark.asyncio
 async def test_file_open_write_new(
-    client_id, client_secret, test_machine, test_tmp_dir
+    async_authenticated_client, test_machine, test_tmp_dir
 ):
-    async with AsyncClient(client_id, client_secret) as client:
+    async with async_authenticated_client as client:
         machine = await client.compute(test_machine)
         remote_tmp_dir = await machine.ls(test_tmp_dir, directory=True)
         assert len(remote_tmp_dir) == 1

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -1,15 +1,12 @@
-from sfapi_client import Client
-
-
-def test_projects(client_id, client_secret):
-    with Client(client_id, client_secret) as client:
+def test_projects(authenticated_client):
+    with authenticated_client as client:
         user = client.user()
         projects = user.projects()
         assert projects
 
 
-def test_roles(client_id, client_secret):
-    with Client(client_id, client_secret) as client:
+def test_roles(authenticated_client):
+    with authenticated_client as client:
         user = client.user()
         roles = user.roles()
         assert roles

--- a/tests/test_projects_async.py
+++ b/tests/test_projects_async.py
@@ -1,19 +1,17 @@
 import pytest
 
-from sfapi_client import AsyncClient
-
 
 @pytest.mark.asyncio
-async def test_projects(client_id, client_secret):
-    async with AsyncClient(client_id, client_secret) as client:
+async def test_projects(async_authenticated_client):
+    async with async_authenticated_client as client:
         user = await client.user()
         projects = await user.projects()
         assert projects
 
 
 @pytest.mark.asyncio
-async def test_roles(client_id, client_secret):
-    async with AsyncClient(client_id, client_secret) as client:
+async def test_roles(async_authenticated_client):
+    async with async_authenticated_client as client:
         user = await client.user()
         roles = await user.roles()
         assert roles

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,10 +1,10 @@
 import pytest
-from sfapi_client import Client, StatusValue
+from sfapi_client import StatusValue
 
 
 @pytest.mark.public
-def test_outages_by_resource(test_machine):
-    with Client() as client:
+def test_outages_by_resource(unauthenticated_client, test_machine):
+    with unauthenticated_client as client:
         outages = client.resources.outages(test_machine)
 
         assert len(outages) > 0
@@ -12,8 +12,8 @@ def test_outages_by_resource(test_machine):
 
 
 @pytest.mark.public
-def test_planned_outages_by_resource(test_machine):
-    with Client() as client:
+def test_planned_outages_by_resource(unauthenticated_client, test_machine):
+    with unauthenticated_client as client:
         outages = client.resources.planned_outages(test_machine)
 
         if len(outages) > 0:
@@ -21,8 +21,8 @@ def test_planned_outages_by_resource(test_machine):
 
 
 @pytest.mark.public
-def test_notes_by_resource(test_machine):
-    with Client() as client:
+def test_notes_by_resource(unauthenticated_client, test_machine):
+    with unauthenticated_client as client:
         notes = client.resources.notes(test_machine)
 
         assert len(notes) > 0
@@ -30,16 +30,16 @@ def test_notes_by_resource(test_machine):
 
 
 @pytest.mark.public
-def test_status_by_resource(test_machine):
-    with Client() as client:
+def test_status_by_resource(unauthenticated_client, test_machine):
+    with unauthenticated_client as client:
         status = client.resources.status(test_machine)
 
         assert status.name == test_machine
 
 
 @pytest.mark.public
-def test_outages(test_machine):
-    with Client() as client:
+def test_outages(unauthenticated_client, test_machine):
+    with unauthenticated_client as client:
         outages = client.resources.outages()
 
         assert test_machine.value in outages
@@ -49,8 +49,8 @@ def test_outages(test_machine):
 
 
 @pytest.mark.public
-def test_planned_outages(test_machine):
-    with Client() as client:
+def test_planned_outages(unauthenticated_client, test_machine):
+    with unauthenticated_client as client:
         outages = client.resources.planned_outages()
 
         if test_machine.value in outages:
@@ -60,8 +60,8 @@ def test_planned_outages(test_machine):
 
 
 @pytest.mark.public
-def test_notes(test_machine):
-    with Client() as client:
+def test_notes(unauthenticated_client, test_machine):
+    with unauthenticated_client as client:
         notes = client.resources.notes()
 
         assert test_machine.value in notes
@@ -71,8 +71,8 @@ def test_notes(test_machine):
 
 
 @pytest.mark.public
-def test_status(test_machine):
-    with Client() as client:
+def test_status(unauthenticated_client, test_machine):
+    with unauthenticated_client as client:
         status = client.resources.status()
 
         assert test_machine.value in status
@@ -81,8 +81,8 @@ def test_status(test_machine):
 
 
 @pytest.mark.public
-def test_resouce_status(test_resource):
-    with Client() as client:
+def test_resouce_status(unauthenticated_client, test_resource):
+    with unauthenticated_client as client:
         status = client.resources.status(test_resource)
 
         assert test_resource.value in status.name

--- a/tests/test_resources_async.py
+++ b/tests/test_resources_async.py
@@ -1,12 +1,12 @@
 import pytest
 
-from sfapi_client import AsyncClient, StatusValue
+from sfapi_client import StatusValue
 
 
 @pytest.mark.public
 @pytest.mark.asyncio
-async def test_outages_by_resource(test_machine):
-    async with AsyncClient() as client:
+async def test_outages_by_resource(async_unauthenticated_client, test_machine):
+    async with async_unauthenticated_client as client:
         outages = await client.resources.outages(test_machine)
 
         assert len(outages) > 0
@@ -15,8 +15,10 @@ async def test_outages_by_resource(test_machine):
 
 @pytest.mark.public
 @pytest.mark.asyncio
-async def test_planned_outages_by_resource(test_machine):
-    async with AsyncClient() as client:
+async def test_planned_outages_by_resource(
+    async_unauthenticated_client, token_url, test_machine
+):
+    async with async_unauthenticated_client as client:
         outages = await client.resources.planned_outages(test_machine)
 
         if len(outages) > 0:
@@ -25,8 +27,8 @@ async def test_planned_outages_by_resource(test_machine):
 
 @pytest.mark.public
 @pytest.mark.asyncio
-async def test_notes_by_resource(test_machine):
-    async with AsyncClient() as client:
+async def test_notes_by_resource(async_unauthenticated_client, test_machine):
+    async with async_unauthenticated_client as client:
         notes = await client.resources.notes(test_machine)
 
         assert len(notes) > 0
@@ -35,8 +37,8 @@ async def test_notes_by_resource(test_machine):
 
 @pytest.mark.public
 @pytest.mark.asyncio
-async def test_status_by_resource(test_machine):
-    async with AsyncClient() as client:
+async def test_status_by_resource(async_unauthenticated_client, test_machine):
+    async with async_unauthenticated_client as client:
         status = await client.resources.status(test_machine)
 
         assert status.name == test_machine
@@ -44,8 +46,8 @@ async def test_status_by_resource(test_machine):
 
 @pytest.mark.public
 @pytest.mark.asyncio
-async def test_outages(test_machine):
-    async with AsyncClient() as client:
+async def test_outages(async_unauthenticated_client, test_machine):
+    async with async_unauthenticated_client as client:
         outages = await client.resources.outages()
 
         assert test_machine.value in outages
@@ -56,8 +58,8 @@ async def test_outages(test_machine):
 
 @pytest.mark.public
 @pytest.mark.asyncio
-async def test_planned_outages(test_machine):
-    async with AsyncClient() as client:
+async def test_planned_outages(async_unauthenticated_client, test_machine):
+    async with async_unauthenticated_client as client:
         outages = await client.resources.planned_outages()
 
         if test_machine.value in outages:
@@ -68,8 +70,8 @@ async def test_planned_outages(test_machine):
 
 @pytest.mark.public
 @pytest.mark.asyncio
-async def test_notes(test_machine):
-    async with AsyncClient() as client:
+async def test_notes(async_unauthenticated_client, test_machine):
+    async with async_unauthenticated_client as client:
         notes = await client.resources.notes()
 
         assert test_machine.value in notes
@@ -80,8 +82,8 @@ async def test_notes(test_machine):
 
 @pytest.mark.public
 @pytest.mark.asyncio
-async def test_status(test_machine):
-    async with AsyncClient() as client:
+async def test_status(async_unauthenticated_client, test_machine):
+    async with async_unauthenticated_client as client:
         status = await client.resources.status()
 
         assert test_machine.value in status
@@ -91,8 +93,8 @@ async def test_status(test_machine):
 
 @pytest.mark.public
 @pytest.mark.asyncio
-async def test_resouce_status(test_resource):
-    async with AsyncClient() as client:
+async def test_resouce_status(async_unauthenticated_client, test_resource):
+    async with async_unauthenticated_client as client:
         status = await client.resources.status(test_resource)
 
         assert test_resource.value in status.name

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -1,10 +1,9 @@
 import pytest
-from sfapi_client import Client
 from sfapi_client import SfApiError
 
 
-def test_get_user(client_id, client_secret, test_username):
-    with Client(client_id, client_secret) as client:
+def test_get_user(authenticated_client, test_username):
+    with authenticated_client as client:
         user = client.user(test_username)
         assert user is not None
         assert user.name == test_username
@@ -14,15 +13,15 @@ def test_get_user(client_id, client_secret, test_username):
         assert user.name == test_username
 
 
-def test_get_another_user(client_id, client_secret, test_another_username):
-    with Client(client_id, client_secret) as client:
+def test_get_another_user(authenticated_client, test_another_username):
+    with authenticated_client as client:
         user = client.user(test_another_username)
         assert user is not None
         assert user.name == test_another_username
 
 
-def test_get_user_groups(client_id, client_secret, test_username):
-    with Client(client_id, client_secret) as client:
+def test_get_user_groups(authenticated_client, test_username):
+    with authenticated_client as client:
         user = client.user(test_username)
         assert user is not None
         assert user.name == test_username
@@ -32,10 +31,8 @@ def test_get_user_groups(client_id, client_secret, test_username):
         assert groups
 
 
-def test_get_user_groups_different_user(
-    client_id, client_secret, test_another_username
-):
-    with Client(client_id, client_secret) as client:
+def test_get_user_groups_different_user(authenticated_client, test_another_username):
+    with authenticated_client as client:
         user = client.user(test_another_username)
         assert user is not None
         assert user.name == test_another_username
@@ -44,8 +41,8 @@ def test_get_user_groups_different_user(
             user.groups()
 
 
-def test_get_user_projects(client_id, client_secret, test_username):
-    with Client(client_id, client_secret) as client:
+def test_get_user_projects(authenticated_client, test_username):
+    with authenticated_client as client:
         user = client.user(test_username)
         assert user is not None
         assert user.name == test_username
@@ -55,10 +52,8 @@ def test_get_user_projects(client_id, client_secret, test_username):
         assert projects
 
 
-def test_get_user_projects_different_user(
-    client_id, client_secret, test_another_username
-):
-    with Client(client_id, client_secret) as client:
+def test_get_user_projects_different_user(authenticated_client, test_another_username):
+    with authenticated_client as client:
         user = client.user(test_another_username)
         assert user is not None
         assert user.name == test_another_username

--- a/tests/test_users_async.py
+++ b/tests/test_users_async.py
@@ -1,12 +1,11 @@
 import pytest
 
-from sfapi_client import AsyncClient
 from sfapi_client import SfApiError
 
 
 @pytest.mark.asyncio
-async def test_get_user(client_id, client_secret, test_username):
-    async with AsyncClient(client_id, client_secret) as client:
+async def test_get_user(async_authenticated_client, test_username):
+    async with async_authenticated_client as client:
         user = await client.user(test_username)
         assert user is not None
         assert user.name == test_username
@@ -17,16 +16,16 @@ async def test_get_user(client_id, client_secret, test_username):
 
 
 @pytest.mark.asyncio
-async def test_get_another_user(client_id, client_secret, test_another_username):
-    async with AsyncClient(client_id, client_secret) as client:
+async def test_get_another_user(async_authenticated_client, test_another_username):
+    async with async_authenticated_client as client:
         user = await client.user(test_another_username)
         assert user is not None
         assert user.name == test_another_username
 
 
 @pytest.mark.asyncio
-async def test_get_user_groups(client_id, client_secret, test_username):
-    async with AsyncClient(client_id, client_secret) as client:
+async def test_get_user_groups(async_authenticated_client, test_username):
+    async with async_authenticated_client as client:
         user = await client.user(test_username)
         assert user is not None
         assert user.name == test_username
@@ -38,9 +37,9 @@ async def test_get_user_groups(client_id, client_secret, test_username):
 
 @pytest.mark.asyncio
 async def test_get_user_groups_different_user(
-    client_id, client_secret, test_another_username
+    async_authenticated_client, test_another_username
 ):
-    async with AsyncClient(client_id, client_secret) as client:
+    async with async_authenticated_client as client:
         user = await client.user(test_another_username)
         assert user is not None
         assert user.name == test_another_username
@@ -50,8 +49,8 @@ async def test_get_user_groups_different_user(
 
 
 @pytest.mark.asyncio
-async def test_get_user_projects(client_id, client_secret, test_username):
-    async with AsyncClient(client_id, client_secret) as client:
+async def test_get_user_projects(async_authenticated_client, test_username):
+    async with async_authenticated_client as client:
         user = await client.user(test_username)
         assert user is not None
         assert user.name == test_username
@@ -63,9 +62,9 @@ async def test_get_user_projects(client_id, client_secret, test_username):
 
 @pytest.mark.asyncio
 async def test_get_user_projects_different_user(
-    client_id, client_secret, test_another_username
+    async_authenticated_client, test_another_username
 ):
-    async with AsyncClient(client_id, client_secret) as client:
+    async with async_authenticated_client as client:
         user = await client.user(test_another_username)
         assert user is not None
         assert user.name == test_another_username


### PR DESCRIPTION
This refactors the way client instances are used in test case. We now inject them as fixtures, this allows use the configure the clients in a single place, allowing us to more easily change the configuration, in this case add support for configuring the urls. 