### PR TITLE
Allow an existing access token to be used with client

### DIFF
--- a/src/sfapi_client/_async/client.py
+++ b/src/sfapi_client/_async/client.py
@@ -215,6 +215,7 @@ class AsyncClient:
         key: Optional[Union[str, Path]] = None,
         api_base_url: Optional[str] = SFAPI_BASE_URL,
         token_url: Optional[str] = SFAPI_TOKEN_URL,
+        access_token: Optional[str] = None,
         wait_interval: int = 10,
     ):
         """
@@ -230,6 +231,10 @@ class AsyncClient:
 
         :param client_id: The client ID
         :param secret: The client secret
+        :param key: The path to the client secret file
+        :param api_base_url: The API base URL
+        :param token_url: The token URL
+        :param access_token: An existing access token
 
         :return: The client instance
         :rtype: AsyncClient
@@ -244,36 +249,45 @@ class AsyncClient:
         self._api_base_url = api_base_url
         self._token_url = token_url
         self._client_user = None
-        self.__oauth2_session = None
+        self.__http_client = None
         self._api = None
         self._resources = None
         self._wait_interval = wait_interval
+        self._access_token = access_token
 
     async def __aenter__(self):
         return self
 
-    async def _oauth2_session(self):
-        if self._client_id is None:
-            raise SfApiError("No credentials have been provides")
+    async def _http_client(self):
+        headers = {"accept": "application/json"}
+        # If we have a client_id then we need to use the OAuth2 client
+        if self._client_id is not None:
+            if self.__http_client is None:
+                # Create a new session if we haven't already
+                self.__http_client = AsyncOAuth2Client(
+                    client_id=self._client_id,
+                    client_secret=self._secret,
+                    token_endpoint_auth_method=PrivateKeyJWT(self._token_url),
+                    grant_type="client_credentials",
+                    token_endpoint=self._token_url,
+                    timeout=10.0,
+                    headers=headers,
+                )
 
-        if self.__oauth2_session is None:
-            # Create a new session if we haven't already
-            self.__oauth2_session = AsyncOAuth2Client(
-                client_id=self._client_id,
-                client_secret=self._secret,
-                token_endpoint_auth_method=PrivateKeyJWT(self._token_url),
-                grant_type="client_credentials",
-                token_endpoint=self._token_url,
-                timeout=10.0,
-            )
+                await self.__http_client.fetch_token()
+            else:
+                # We have a session
+                # Make sure it's still active
+                await self.__http_client.ensure_active_token(self.__http_client.token)
+        # Use regular client, but add the access token if we have one
+        elif self.__http_client is None:
+            # We already have an access token
+            if self._access_token is not None:
+                headers.update({"Authorization": f"Bearer {self._access_token}"})
 
-            await self.__oauth2_session.fetch_token()
-        else:
-            # We have a session
-            # Make sure it's still active
-            await self.__oauth2_session.ensure_active_token(self.__oauth2_session.token)
+            self.__http_client = httpx.AsyncClient(headers=headers)
 
-        return self.__oauth2_session
+        return self.__http_client
 
     @property
     async def token(self) -> str:
@@ -281,16 +295,18 @@ class AsyncClient:
         Bearer token string which can be helpful for debugging through swagger UI.
         """
 
-        if self._client_id is not None:
-            oauth_session = await self._oauth2_session()
-            return oauth_session.token["access_token"]
+        if self._access_token is not None:
+            return self._access_token
+        elif self._client_id is not None:
+            client = await self._http_client()
+            return client.token["access_token"]
 
     async def close(self):
         """
         Release resources associated with the client instance.
         """
-        if self.__oauth2_session is not None:
-            await self.__oauth2_session.aclose()
+        if self.__http_client is not None:
+            await self.__http_client.aclose()
 
     async def __aexit__(self, type, value, traceback):
         await self.close()
@@ -345,29 +361,11 @@ class AsyncClient:
         stop=tenacity.stop_after_attempt(MAX_RETRY),
     )
     async def get(self, url: str, params: Dict[str, Any] = {}) -> httpx.Response:
-        if self._client_id is not None:
-            oauth_session = await self._oauth2_session()
-
-            r = await oauth_session.get(
-                f"{self._api_base_url}/{url}",
-                headers={
-                    "Authorization": oauth_session.token["access_token"],
-                    "accept": "application/json",
-                },
-                params=params,
-            )
-        # Use regular client if we are hitting an endpoint that don't need
-        # auth.
-        else:
-            async with httpx.AsyncClient() as client:
-                r = await client.get(
-                    f"{self._api_base_url}/{url}",
-                    headers={
-                        "accept": "application/json",
-                    },
-                    params=params,
-                )
-
+        client = await self._http_client()
+        r = await client.get(
+            f"{self._api_base_url}/{url}",
+            params=params,
+        )
         r.raise_for_status()
 
         return r
@@ -380,14 +378,10 @@ class AsyncClient:
         stop=tenacity.stop_after_attempt(MAX_RETRY),
     )
     async def post(self, url: str, data: Dict[str, Any]) -> httpx.Response:
-        oauth_session = await self._oauth2_session()
+        client = await self._http_client()
 
-        r = await oauth_session.post(
+        r = await client.post(
             f"{self._api_base_url}/{url}",
-            headers={
-                "Authorization": oauth_session.token["access_token"],
-                "accept": "application/json",
-            },
             data=data,
         )
         r.raise_for_status()
@@ -404,14 +398,10 @@ class AsyncClient:
     async def put(
         self, url: str, data: Dict[str, Any] = None, files: Dict[str, Any] = None
     ) -> httpx.Response:
-        oauth_session = await self._oauth2_session()
+        client = await self._http_client()
 
-        r = await oauth_session.put(
+        r = await client.put(
             f"{self._api_base_url}/{url}",
-            headers={
-                "Authorization": oauth_session.token["access_token"],
-                "accept": "application/json",
-            },
             data=data,
             files=files,
         )
@@ -427,14 +417,10 @@ class AsyncClient:
         stop=tenacity.stop_after_attempt(MAX_RETRY),
     )
     async def delete(self, url: str) -> httpx.Response:
-        oauth_session = await self._oauth2_session()
+        client = await self._http_client()
 
-        r = await oauth_session.delete(
+        r = await client.delete(
             f"{self._api_base_url}/{url}",
-            headers={
-                "Authorization": oauth_session.token["access_token"],
-                "accept": "application/json",
-            },
         )
         r.raise_for_status()
 

--- a/src/sfapi_client/_async/compute.py
+++ b/src/sfapi_client/_async/compute.py
@@ -23,7 +23,7 @@ Machine.__str__ = lambda self: self.value
 
 def check_auth(method: Callable):
     def wrapper(self, *args, **kwargs):
-        if self.client._client_id is None:
+        if self.client._client_id is None and self.client._access_token is None:
             raise SfApiError(
                 f"Cannot call {self.__class__.__name__}.{method.__name__}() with an unauthenticated client."  # noqa: E501
             )

--- a/src/sfapi_client/_sync/compute.py
+++ b/src/sfapi_client/_sync/compute.py
@@ -23,7 +23,7 @@ Machine.__str__ = lambda self: self.value
 
 def check_auth(method: Callable):
     def wrapper(self, *args, **kwargs):
-        if self.client._client_id is None:
+        if self.client._client_id is None and self.client._access_token is None:
             raise SfApiError(
                 f"Cannot call {self.__class__.__name__}.{method.__name__}() with an unauthenticated client."  # noqa: E501
             )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,7 @@ class Settings(BaseSettings):
     TEST_GROUP: Optional[str] = None
     DEV_API_URL: str = "https://api-dev.nersc.gov/api/v1.2"
     DEV_TOKEN_URL: str = "https://oidc-dev.nersc.gov/c2id/token"
+    ACCESS_TOKEN: Optional[str] = None
 
     model_config = ConfigDict(case_sensitive=True, env_file=".env")
 
@@ -168,3 +169,8 @@ def async_authenticated_client(api_base_url, token_url, client_id, client_secret
         client_id=client_id,
         secret=client_secret,
     )
+
+
+@pytest.fixture
+def access_token():
+    return settings.ACCESS_TOKEN

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,6 @@
 import pytest
 
-from sfapi_client import SfApiError
+from sfapi_client import SfApiError, Client
 
 
 @pytest.mark.public
@@ -15,3 +15,9 @@ def test_no_creds_auth_required(unauthenticated_client, test_machine):
         machine = client.compute(test_machine)
         with pytest.raises(SfApiError):
             machine.jobs()
+
+
+def test_access_token(api_base_url, access_token, test_machine, test_username):
+    with Client(api_base_url=api_base_url, access_token=access_token) as client:
+        machine = client.compute(test_machine)
+        machine.jobs(user=test_username)

--- a/tests/test_client_async.py
+++ b/tests/test_client_async.py
@@ -1,6 +1,6 @@
 import pytest
 
-from sfapi_client import SfApiError
+from sfapi_client import SfApiError, AsyncClient
 
 
 @pytest.mark.public
@@ -17,3 +17,12 @@ async def test_no_creds_auth_required(async_unauthenticated_client, test_machine
         machine = await client.compute(test_machine)
         with pytest.raises(SfApiError):
             await machine.jobs()
+
+
+@pytest.mark.asyncio
+async def test_access_token(api_base_url, access_token, test_machine, test_username):
+    async with AsyncClient(
+        api_base_url=api_base_url, access_token=access_token
+    ) as client:
+        machine = await client.compute(test_machine)
+        await machine.jobs(user=test_username)


### PR DESCRIPTION
This PR refactors the way we create a http client to make api calls. This is done to allow the use of an existing access token when creating a client, an example of this use case would be calling api from within a REST endpoint, where you already have a valid access token.