### PR TITLE
Add missing dependencies to requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,7 @@ pytest-asyncio
 pytest-mock
 mkdocs-jupyter
 datamodel-code-generator[http]
+cryptography
+authlib
+tenacity
+pydantic_settings


### PR DESCRIPTION
Discovered attempting to get the tests to run

Personally I would suggest pinning the dependencies and switching to a tool that handles virtualenv creation like pipenv / poetry / uv but that's obviously not my call

Ref: #87 