### PR TITLE
Add `json` kwarg to `[Async]Client.post()`

### DIFF
--- a/src/sfapi_client/_async/client.py
+++ b/src/sfapi_client/_async/client.py
@@ -382,12 +382,18 @@ class AsyncClient:
         wait=tenacity.wait_exponential(max=MAX_RETRY),
         stop=tenacity.stop_after_attempt(MAX_RETRY),
     )
-    async def post(self, url: str, data: Dict[str, Any]) -> httpx.Response:
+    async def post(
+        self,
+        url: str,
+        data: Dict[str, Any] = None,
+        json: Dict[str, Any] = None
+    ) -> httpx.Response:
         client = await self._http_client()
 
         r = await client.post(
             f"{self._api_base_url}/{url}",
             data=data,
+            json=json,
         )
         r.raise_for_status()
 

--- a/src/sfapi_client/_async/client.py
+++ b/src/sfapi_client/_async/client.py
@@ -383,10 +383,7 @@ class AsyncClient:
         stop=tenacity.stop_after_attempt(MAX_RETRY),
     )
     async def post(
-        self,
-        url: str,
-        data: Dict[str, Any] = None,
-        json: Dict[str, Any] = None
+        self, url: str, data: Dict[str, Any] = None, json: Dict[str, Any] = None
     ) -> httpx.Response:
         client = await self._http_client()
 

--- a/src/sfapi_client/_sync/client.py
+++ b/src/sfapi_client/_sync/client.py
@@ -382,12 +382,18 @@ class Client:
         wait=tenacity.wait_exponential(max=MAX_RETRY),
         stop=tenacity.stop_after_attempt(MAX_RETRY),
     )
-    def post(self, url: str, data: Dict[str, Any]) -> httpx.Response:
+    def post(
+        self,
+        url: str,
+        data: Dict[str, Any] = None,
+        json: Dict[str, Any] = None
+    ) -> httpx.Response:
         client = self._http_client()
 
         r = client.post(
             f"{self._api_base_url}/{url}",
             data=data,
+            json=json,
         )
         r.raise_for_status()
 


### PR DESCRIPTION
Allows using the clients to call the `callback` endpoint in the Superfacility beta API.

Closes #87 

Manual testing:

```python
~/github/mrcreosote/sfapi_client$ ipython
Python 3.11.3 (main, Apr  5 2023, 14:14:40) [GCC 7.5.0]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.27.0 -- An enhanced Interactive Python. Type '?' for help.

In [3]: from sfapi_client import AsyncClient, Client
f
In [4]: from sfapi_client.compute import Machine

In [5]: beta_url="https://api.nersc.gov/api/beta"

In [6]: async with AsyncClient(client_id=nersc_client_id, secret=nersc_private_k
   ...: ey) as cli:
   ...:     pm = await cli.compute(Machine.perlmutter)
   ...:     ret = await pm.run("ls ~")
   ...:     print(ret)
   ...:
cdm
dots
Downloads
github
mash
minio
tmp

In [7]: with Client(client_id=nersc_client_id, secret=nersc_private_key) as cli:
   ...:
   ...:     pm = cli.compute(Machine.perlmutter)
   ...:     ret = pm.run("ls ~")
   ...:     print(ret)
   ...:
cdm
dots
Downloads
github
mash
minio
tmp

In [8]: async with AsyncClient(api_base_url=beta_url, client_id=nersc_client_id,
   ...:  secret=nersc_private_key) as cli:
   ...:     ret = await cli.post("callback/", json={
   ...:         "timeout": 10,
   ...:         "path_condition": {
   ...:             "path": "~/foo",
   ...:             "machine": "perlmutter",
   ...:         },
   ...:         "url": "https://teletubbiessuperfans.com/signup",
   ...:     })
   ...:     print(ret.json())
   ...:
{'timeout': 10, 'path_condition': {'path': '~/foo', 'machine':
'perlmutter'}, 'url': 'https://teletubbiessuperfans.com/signup'}

In [9]: with Client(api_base_url=beta_url, client_id=nersc_client_id, secret=ner
   ...: sc_private_key) as cli:
   ...:     ret = cli.post("callback/", json={
   ...:         "timeout": 10,
   ...:         "path_condition": {
   ...:             "path": "~/foo",
   ...:             "machine": "perlmutter",
   ...:         },
   ...:         "url": "https://teletubbiessuperfans.com/signup",
   ...:     })
   ...:     print(ret.json())
   ...:
{'timeout': 10, 'path_condition': {'path': '~/foo', 'machine': 
'perlmutter'}, 'url': 'https://teletubbiessuperfans.com/signup'}

```