### PR TITLE
Use status to determine exit condition

### DIFF
--- a/src/sfapi_client/_async/compute.py
+++ b/src/sfapi_client/_async/compute.py
@@ -58,10 +58,11 @@ class AsyncCompute(ComputeBase):
             json_response = r.json()
             task = Task.model_validate(json_response)
 
-            if task.status.lower() in ["error", "failed"]:
+            status = task.status.lower()
+            if status in ["error", "failed"]:
                 raise SfApiError(task.result)
 
-            if task.result is None:
+            if status not in ["completed", "cancelled"]:
                 await _ASYNC_SLEEP(1)
                 continue
 

--- a/src/sfapi_client/_sync/compute.py
+++ b/src/sfapi_client/_sync/compute.py
@@ -58,10 +58,11 @@ class Compute(ComputeBase):
             json_response = r.json()
             task = Task.model_validate(json_response)
 
-            if task.status.lower() in ["error", "failed"]:
+            status = task.status.lower()
+            if status in ["error", "failed"]:
                 raise SfApiError(task.result)
 
-            if task.result is None:
+            if status not in ["completed", "cancelled"]:
                 _SLEEP(1)
                 continue
 


### PR DESCRIPTION
As the result object of a task can now be present while the task is running we need to use the status to wait for task completion.