### PR TITLE
Pass raw JSON to authlib

### DIFF
--- a/docs/quickstart/index.md
+++ b/docs/quickstart/index.md
@@ -95,13 +95,12 @@ export SFAPI_SECRET='{"kty": "RSA", "n": ...}'
     ```pycon
     >>> from sfapi_client import AsyncClient
     >>> from sfapi_client.compute import Machine
-    >>> from authlib.jose import JsonWebKey
     >>> import json
     >>> import os
     >>>
     >>> client_id = os.getenv("SFAPI_CLIENT_ID")
     >>> sfapi_secret = os.getenv("SFAPI_SECRET")
-    >>> client_secret = JsonWebKey.import_key(json.loads(sfapi_secret))
+    >>> client_secret = json.loads(sfapi_secret)
     >>>
     >>> async with AsyncClient(client_id, client_secret) as client:
     ...     perlmutter = await client.compute(Machine.perlmutter)
@@ -110,13 +109,12 @@ export SFAPI_SECRET='{"kty": "RSA", "n": ...}'
     ```pycon
     >>> from sfapi_client import Client
     >>> from sfapi_client.compute import Machine
-    >>> from authlib.jose import JsonWebKey
     >>> import json
     >>> import os
     >>>
     >>> client_id = os.getenv("SFAPI_CLIENT_ID")
     >>> sfapi_secret = os.getenv("SFAPI_SECRET")
-    >>> client_secret = JsonWebKey.import_key(json.loads(sfapi_secret))
+    >>> client_secret = json.loads(sfapi_secret)
     >>>
     >>> with Client(client_id, client_secret) as client:
     ...     perlmutter = client.compute(Machine.perlmutter)

--- a/src/sfapi_client/_async/client.py
+++ b/src/sfapi_client/_async/client.py
@@ -7,7 +7,6 @@ from authlib.integrations.httpx_client.oauth2_client import AsyncOAuth2Client
 from authlib.oauth2.rfc7523 import PrivateKeyJWT
 import httpx
 import tenacity
-from authlib.jose import JsonWebKey
 
 from .compute import Machine, AsyncCompute
 from ..exceptions import ClientKeyError
@@ -352,7 +351,7 @@ class AsyncClient:
             if key_path.suffix == ".json":
                 # Json file in the format {"client_id": "", "secret": ""}
                 json_web_key = json.loads(secret.read())
-                self._secret = JsonWebKey.import_key(json_web_key["secret"])
+                self._secret = json_web_key["secret"]
                 self._client_id = json_web_key["client_id"]
             else:
                 self._secret = secret.read()

--- a/src/sfapi_client/_sync/client.py
+++ b/src/sfapi_client/_sync/client.py
@@ -7,7 +7,6 @@ from authlib.integrations.httpx_client.oauth2_client import OAuth2Client
 from authlib.oauth2.rfc7523 import PrivateKeyJWT
 import httpx
 import tenacity
-from authlib.jose import JsonWebKey
 
 from .compute import Machine, Compute
 from ..exceptions import ClientKeyError
@@ -352,7 +351,7 @@ class Client:
             if key_path.suffix == ".json":
                 # Json file in the format {"client_id": "", "secret": ""}
                 json_web_key = json.loads(secret.read())
-                self._secret = JsonWebKey.import_key(json_web_key["secret"])
+                self._secret = json_web_key["secret"]
                 self._client_id = json_web_key["client_id"]
             else:
                 self._secret = secret.read()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from cryptography.hazmat.primitives.asymmetric import rsa
 
 import pytest
-from authlib.jose import JsonWebKey
 
 from sfapi_client.compute import Machine
 from sfapi_client import Resource
@@ -53,7 +52,7 @@ def client_secret():
     if isinstance(json_web_key, str):
         json_web_key = json.loads(json_web_key)
 
-    return JsonWebKey.import_key(json_web_key)
+    return json_web_key
 
 
 @pytest.fixture
@@ -68,7 +67,7 @@ def dev_client_secret():
     if isinstance(json_web_key, str):
         json_web_key = json.loads(json_web_key)
 
-    return JsonWebKey.import_key(json_web_key)
+    return json_web_key
 
 
 @pytest.fixture


### PR DESCRIPTION
Recent versions of authlib no longer accept JsonWebKey for the client secret, we need to pass the JSON.