### PR TITLE
Add run_task

### DIFF
--- a/scripts/run.py
+++ b/scripts/run.py
@@ -23,6 +23,8 @@ def run_unasync():
         "AsyncApi": "Api",
         "AsyncResources": "Resources",
         "AsyncCompute": "Compute",
+        "AsyncCommandTask": "CommandTask",
+        "AsyncCommandTaskResult": "CommandTaskResult",
         "AsyncGroup": "Group",
         "AsyncGroupMember": "GroupMember",
         "AsyncRemotePath": "RemotePath",

--- a/src/sfapi_client/_async/compute.py
+++ b/src/sfapi_client/_async/compute.py
@@ -1,12 +1,11 @@
 from typing import Dict, List, Optional, Union
-import json
-from pydantic import PrivateAttr, ConfigDict
+from pydantic import PrivateAttr, ConfigDict, BaseModel
 from ..exceptions import SfApiError
 from .._utils import _ASYNC_SLEEP
 from .jobs import AsyncJobSacct, AsyncJobSqueue, JobCommand
 from .._models import (
     AppRoutersStatusModelsStatus as ComputeBase,
-    Task,
+    Task as TaskResponse,
     PublicHost as Machine,
     BodyRunCommandUtilitiesCommandMachinePost as RunCommandBody,
     AppRoutersComputeModelsCommandOutput as RunCommandResponse,
@@ -14,11 +13,85 @@ from .._models import (
 )
 from .paths import AsyncRemotePath
 from .._monitor import AsyncJobMonitor
-from .._compute import CommandResult, SubmitJobResponse, SubmitJobResponseStatus
+from .._compute import SubmitJobResponse, SubmitJobResponseStatus, TaskStatus
 from .._utils import check_auth
 
 # Patch to return str names from Enum of py3.11
 Machine.__str__ = lambda self: self.value
+
+
+class AsyncCommandTaskResult(BaseModel):
+    """
+    Result data returned by a command execution task.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    status: Optional[str] = None
+    output: Optional[str] = None
+    error: Optional[str] = None
+    exit_code: Optional[int] = None
+
+
+class AsyncCommandTask(BaseModel):
+    """
+    Models an asynchronous command execution task.
+    """
+
+    compute: "AsyncCompute"
+    id: str
+    status: Optional[TaskStatus] = None
+    result: Optional[AsyncCommandTaskResult] = None
+
+    async def _fetch(self) -> TaskResponse:
+        """
+        Fetch the latest task state from the API.
+
+        :return: The raw task response returned by the API.
+        """
+        r = await self.compute.client.get(f"tasks/{self.id}")
+        json_response = r.json()
+
+        return TaskResponse.model_validate(json_response)
+
+    async def update(self):
+        """
+        Refresh the task state.
+
+        :return: The updated task instance.
+        """
+        task = await self._fetch()
+        if task.status is not None:
+            # Map the status return by the API (lowercase string) to our TaskStatus enum ( uppercase )
+            # We do this for consistency as all our enums are uppercase
+            self.status = TaskStatus[task.status.upper()]
+
+        if task.result is not None:
+            self.result = AsyncCommandTaskResult.model_validate_json(task.result)
+
+        return self
+
+    async def _wait(self):
+        while True:
+            await self.update()
+
+            if self.status in [
+                TaskStatus.COMPLETED,
+                TaskStatus.CANCELLED,
+                TaskStatus.FAILED,
+            ]:
+                return self
+
+            await _ASYNC_SLEEP(1)
+
+    def __await__(self):
+        return self._wait().__await__()
+
+    async def cancel(self):
+        """
+        Cancel the running task.
+        """
+        await self.compute.client.delete(f"tasks/{self.id}")
 
 
 class AsyncCompute(ComputeBase):
@@ -36,18 +109,17 @@ class AsyncCompute(ComputeBase):
             kwargs["exclude"] = {"client"}
         return super().dict(*args, **kwargs)
 
-    async def _wait_for_task(self, task_id) -> str:
+    async def _wait_for_task(self, task_id) -> AsyncCommandTaskResult:
+
+        task = AsyncCommandTask(compute=self, id=task_id)
+
         while True:
-            r = await self.client.get(f"tasks/{task_id}")
+            await task.update()
 
-            json_response = r.json()
-            task = Task.model_validate(json_response)
-
-            status = task.status.lower()
-            if status in ["error", "failed"]:
+            if task.status is TaskStatus.FAILED:
                 raise SfApiError(task.result)
 
-            if status not in ["completed", "cancelled"]:
+            if task.status not in [TaskStatus.COMPLETED, TaskStatus.CANCELLED]:
                 await _ASYNC_SLEEP(1)
                 continue
 
@@ -92,11 +164,11 @@ class AsyncCompute(ComputeBase):
 
         # We now need waiting for the task to complete!
         task_result = await self._wait_for_task(task_id)
-        result = json.loads(task_result)
-        if result.get("status") == "error":
-            raise SfApiError(result["error"])
+        if task_result.status == "error":
+            raise SfApiError(task_result.error)
 
-        jobid = result.get("jobid")
+        # Get the jobid from the extra fields of the result
+        jobid = task_result.__pydantic_extra__.get("jobid")
         if jobid is None:
             raise SfApiError(f"Unable to extract jobid if for task: {task_id}")
 
@@ -140,6 +212,17 @@ class AsyncCompute(ComputeBase):
 
     @check_auth
     async def run(self, args: Union[str, AsyncRemotePath, List[str]]):
+        task = await self._run_task(args)
+        await task._wait()
+
+        if task.result.error:
+            raise SfApiError(task.result.error)
+
+        return task.result.output
+
+    async def _run_task(
+        self, args: Union[str, AsyncRemotePath, List[str]]
+    ) -> AsyncCommandTask:
         body: RunCommandBody = {
             "executable": args if not isinstance(args, list) else " ".join(args)
         }
@@ -150,13 +233,19 @@ class AsyncCompute(ComputeBase):
         if run_response.status == RunCommandResponseStatus.ERROR:
             raise SfApiError(run_response.error)
 
-        task_id = run_response.task_id
-        task_result = await self._wait_for_task(task_id)
-        command_result = CommandResult.model_validate_json(task_result)
-        if command_result.status == "error":
-            raise SfApiError(command_result.error)
+        return AsyncCommandTask(compute=self, id=run_response.task_id)
 
-        return command_result.output
+    @check_auth
+    async def run_task(
+        self, args: Union[str, AsyncRemotePath, List[str]]
+    ) -> AsyncCommandTask:
+        """
+        Submit a command to the compute resource and return a task.
+
+        :param args: Command to execute.
+        :return: Task object that can be awaited ( async version ), updated, or cancelled.
+        """
+        return await self._run_task(args)
 
     async def outages(self):
         return await self.client.resources.outages(self.name)

--- a/src/sfapi_client/_async/paths.py
+++ b/src/sfapi_client/_async/paths.py
@@ -161,7 +161,8 @@ class AsyncRemotePath(PathBase):
             raise IsADirectoryError(self._path)
 
         r = await self.compute.client.get(
-            f"utilities/download/{self.compute.name}/{self._path}?binary={binary}"
+            f"utilities/download/{self.compute.name}/{self._path}",
+            params={"binary": binary},
         )
         json_response = r.json()
         download_response = FileDownloadResponse.model_validate(json_response)

--- a/src/sfapi_client/_async/users.py
+++ b/src/sfapi_client/_async/users.py
@@ -24,10 +24,12 @@ class AsyncUser(UserBase):
         username: Optional[str] = None,  # noqa: F821
     ):  # noqa: F821
         url = "account/"
-        if username is not None:
-            url = f"{url}?username={username}"
+        params = {}
 
-        response = await client.get(url)
+        if username is not None:
+            params["username"] = username
+
+        response = await client.get(url, params=params)
         json_response = response.json()
 
         user = AsyncUser.model_validate(dict(json_response, client=client))

--- a/src/sfapi_client/_compute.py
+++ b/src/sfapi_client/_compute.py
@@ -18,3 +18,10 @@ class CommandResult(BaseModel):
     status: str
     output: Optional[str]
     error: Optional[str]
+
+
+class TaskStatus(str, Enum):
+    NEW = "NEW"
+    COMPLETED = "COMPLETED"
+    CANCELLED = "CANCELLED"
+    FAILED = "FAILED"

--- a/src/sfapi_client/_sync/compute.py
+++ b/src/sfapi_client/_sync/compute.py
@@ -1,12 +1,12 @@
 from typing import Dict, List, Optional, Union
 import json
-from pydantic import PrivateAttr, ConfigDict
+from pydantic import PrivateAttr, ConfigDict, BaseModel
 from ..exceptions import SfApiError
 from .._utils import _SLEEP
 from .jobs import JobSacct, JobSqueue, JobCommand
 from .._models import (
     AppRoutersStatusModelsStatus as ComputeBase,
-    Task,
+    Task as TaskResponse,
     PublicHost as Machine,
     BodyRunCommandUtilitiesCommandMachinePost as RunCommandBody,
     AppRoutersComputeModelsCommandOutput as RunCommandResponse,
@@ -14,11 +14,85 @@ from .._models import (
 )
 from .paths import RemotePath
 from .._monitor import SyncJobMonitor
-from .._compute import CommandResult, SubmitJobResponse, SubmitJobResponseStatus
+from .._compute import SubmitJobResponse, SubmitJobResponseStatus, TaskStatus
 from .._utils import check_auth
 
 # Patch to return str names from Enum of py3.11
 Machine.__str__ = lambda self: self.value
+
+
+class CommandTaskResult(BaseModel):
+    """
+    Result data returned by a command execution task.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    status: Optional[str] = None
+    output: Optional[str] = None
+    error: Optional[str] = None
+    exit_code: Optional[int] = None
+
+
+class CommandTask(BaseModel):
+    """
+    Models an asynchronous command execution task.
+    """
+
+    compute: "Compute"
+    id: str
+    status: Optional[TaskStatus] = None
+    result: Optional[CommandTaskResult] = None
+
+    def _fetch(self) -> TaskResponse:
+        """
+        Fetch the latest task state from the API.
+
+        :return: The raw task response returned by the API.
+        """
+        r = self.compute.client.get(f"tasks/{self.id}")
+        json_response = r.json()
+
+        return TaskResponse.model_validate(json_response)
+
+    def update(self):
+        """
+        Refresh the task state.
+
+        :return: The updated task instance.
+        """
+        task = self._fetch()
+        if task.status is not None:
+            # Map the status return by the API (lowercase string) to our TaskStatus enum ( uppercase )
+            # We do this for consistency as all our enums are uppercase
+            self.status = TaskStatus[task.status.upper()]
+
+        if task.result is not None:
+            self.result = CommandTaskResult.model_validate_json(task.result)
+
+        return self
+
+    def _wait(self):
+        while True:
+            self.update()
+
+            if self.status in [
+                TaskStatus.COMPLETED,
+                TaskStatus.CANCELLED,
+                TaskStatus.FAILED,
+            ]:
+                return self
+
+            _SLEEP(1)
+
+    def __await__(self):
+        return self._wait().__await__()
+
+    def cancel(self):
+        """
+        Cancel the running task.
+        """
+        self.compute.client.delete(f"tasks/{self.id}")
 
 
 class Compute(ComputeBase):
@@ -36,18 +110,17 @@ class Compute(ComputeBase):
             kwargs["exclude"] = {"client"}
         return super().dict(*args, **kwargs)
 
-    def _wait_for_task(self, task_id) -> str:
+    def _wait_for_task(self, task_id) -> CommandTaskResult:
+
+        task = CommandTask(compute=self, id=task_id)
+
         while True:
-            r = self.client.get(f"tasks/{task_id}")
+            task.update()
 
-            json_response = r.json()
-            task = Task.model_validate(json_response)
-
-            status = task.status.lower()
-            if status in ["error", "failed"]:
+            if task.status is TaskStatus.FAILED:
                 raise SfApiError(task.result)
 
-            if status not in ["completed", "cancelled"]:
+            if task.status not in [TaskStatus.COMPLETED, TaskStatus.CANCELLED]:
                 _SLEEP(1)
                 continue
 
@@ -92,11 +165,11 @@ class Compute(ComputeBase):
 
         # We now need waiting for the task to complete!
         task_result = self._wait_for_task(task_id)
-        result = json.loads(task_result)
-        if result.get("status") == "error":
-            raise SfApiError(result["error"])
+        if task_result.status == "error":
+            raise SfApiError(task_result.error)
 
-        jobid = result.get("jobid")
+        # Get the jobid from the extra fields of the result
+        jobid = task_result.__pydantic_extra__.get("jobid")
         if jobid is None:
             raise SfApiError(f"Unable to extract jobid if for task: {task_id}")
 
@@ -140,6 +213,17 @@ class Compute(ComputeBase):
 
     @check_auth
     def run(self, args: Union[str, RemotePath, List[str]]):
+        task = self._run_task(args)
+        task._wait()
+
+        if task.result.error:
+            raise SfApiError(task.result.error)
+
+        return task.result.output
+
+    def _run_task(
+        self, args: Union[str, RemotePath, List[str]]
+    ) -> CommandTask:
         body: RunCommandBody = {
             "executable": args if not isinstance(args, list) else " ".join(args)
         }
@@ -150,13 +234,19 @@ class Compute(ComputeBase):
         if run_response.status == RunCommandResponseStatus.ERROR:
             raise SfApiError(run_response.error)
 
-        task_id = run_response.task_id
-        task_result = self._wait_for_task(task_id)
-        command_result = CommandResult.model_validate_json(task_result)
-        if command_result.status == "error":
-            raise SfApiError(command_result.error)
+        return CommandTask(compute=self, id=run_response.task_id)
 
-        return command_result.output
+    @check_auth
+    def run_task(
+        self, args: Union[str, RemotePath, List[str]]
+    ) -> CommandTask:
+        """
+        Submit a command to the compute resource and return a task.
+
+        :param args: Command to execute.
+        :return: Task object that can be awaited ( version ), updated, or cancelled.
+        """
+        return self._run_task(args)
 
     def outages(self):
         return self.client.resources.outages(self.name)

--- a/src/sfapi_client/_sync/paths.py
+++ b/src/sfapi_client/_sync/paths.py
@@ -161,7 +161,8 @@ class RemotePath(PathBase):
             raise IsADirectoryError(self._path)
 
         r = self.compute.client.get(
-            f"utilities/download/{self.compute.name}/{self._path}?binary={binary}"
+            f"utilities/download/{self.compute.name}/{self._path}",
+            params={"binary": binary}
         )
         json_response = r.json()
         download_response = FileDownloadResponse.model_validate(json_response)

--- a/src/sfapi_client/_sync/users.py
+++ b/src/sfapi_client/_sync/users.py
@@ -24,10 +24,12 @@ class User(UserBase):
         username: Optional[str] = None,  # noqa: F821
     ):  # noqa: F821
         url = "account/"
-        if username is not None:
-            url = f"{url}?username={username}"
+        params = {}
 
-        response = client.get(url)
+        if username is not None:
+            params["username"] = username
+
+        response = client.get(url, params=params)
         json_response = response.json()
 
         user = User.model_validate(dict(json_response, client=client))

--- a/src/sfapi_client/compute.py
+++ b/src/sfapi_client/compute.py
@@ -1,3 +1,8 @@
-from ._async.compute import AsyncCompute  # noqa: F401
-from ._sync.compute import Compute  # noqa: F401
+from ._async.compute import (
+    AsyncCompute,  # noqa: F401
+    AsyncCommandTask,  # noqa: F401
+    AsyncCommandTaskResult,  # noqa: F401
+)
+from ._sync.compute import Compute, CommandTask, CommandTaskResult  # noqa: F401
 from ._models import PublicHost as Machine  # noqa: F401
+from ._compute import TaskStatus  # noqa: F401

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -1,6 +1,32 @@
+import time
 from pathlib import Path
 
 from sfapi_client.jobs import JobState
+from sfapi_client.compute import CommandTask, TaskStatus
+
+
+def _periodic_command():
+    return "bash -lc 'i=0; while [ $i -lt 30 ]; do echo tick-$i; i=$((i+1)); sleep 1; done'"
+
+
+def _failing_command():
+    return "bash -lc 'echo failing >&2; exit 1'"
+
+
+def _poll_task(task, predicate, timeout=60, pause=1):
+    deadline = time.time() + timeout
+
+    while True:
+        task.update()
+        if predicate(task):
+            return task
+
+        if time.time() >= deadline:
+            raise AssertionError(
+                f"task did not reach the expected state within {timeout}s"
+            )
+
+        time.sleep(pause)
 
 
 def test_compute(authenticated_client, test_machine):
@@ -97,3 +123,74 @@ def test_run_arg_path(authenticated_client, test_machine):
         output = machine.run(remote_path)
 
         assert output
+
+
+def test_run_task(authenticated_client, test_machine):
+    with authenticated_client as client:
+        machine = client.compute(test_machine)
+
+        task = machine.run_task("echo hello")
+
+        assert isinstance(task, CommandTask)
+        assert task.id
+        assert task.status is None
+        assert task.result is None
+
+
+def test_run_task_wait(authenticated_client, test_machine):
+    with authenticated_client as client:
+        machine = client.compute(test_machine)
+
+        task = machine.run_task("echo hello")
+        _poll_task(task, lambda t: t.status is TaskStatus.COMPLETED)
+
+        assert task.status is TaskStatus.COMPLETED
+        assert task.result is not None
+        assert task.result.output is not None
+        assert "hello" in task.result.output
+        assert task.result.error in ("", None)
+
+
+def test_run_task_update(authenticated_client, test_machine):
+    with authenticated_client as client:
+        machine = client.compute(test_machine)
+
+        task = machine.run_task(_periodic_command())
+        updated = _poll_task(
+            task,
+            lambda t: t.result is not None and t.status is TaskStatus.COMPLETED,
+            timeout=90,
+        )
+
+        assert updated is task
+        assert task.status is TaskStatus.COMPLETED
+        assert task.result is not None
+        assert task.result.output is not None
+        assert "tick-" in task.result.output
+
+
+def test_run_task_cancel(authenticated_client, test_machine):
+    with authenticated_client as client:
+        machine = client.compute(test_machine)
+
+        task = machine.run_task(_periodic_command())
+        time.sleep(2)
+        task.cancel()
+
+        _poll_task(task, lambda t: t.status is TaskStatus.CANCELLED, timeout=90)
+        assert task.status == TaskStatus.CANCELLED
+
+
+def test_run_task_error(authenticated_client, test_machine):
+    with authenticated_client as client:
+        machine = client.compute(test_machine)
+
+        task = machine.run_task(_failing_command())
+        _poll_task(task, lambda t: t.status is TaskStatus.COMPLETED, timeout=90)
+
+        assert task.status is TaskStatus.COMPLETED
+        assert task.result is not None
+        assert task.result.error == "failing\n"
+        assert task.result.output == ""
+        assert task.result.exit_code == 1
+        assert task.result.status == "error"

--- a/tests/test_compute_async.py
+++ b/tests/test_compute_async.py
@@ -1,7 +1,35 @@
+import asyncio
+
 import pytest
 from pathlib import Path
 
+from sfapi_client.compute import AsyncCommandTask, TaskStatus
 from sfapi_client.jobs import JobState
+
+
+def _periodic_command():
+    return "bash -lc 'i=0; while [ $i -lt 30 ]; do echo tick-$i; i=$((i+1)); sleep 1; done'"
+
+
+def _failing_command():
+    return "bash -lc 'echo failing >&2; exit 1'"
+
+
+async def _poll_task(task, predicate, timeout=60, pause=1):
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+
+    while True:
+        await task.update()
+        if predicate(task):
+            return task
+
+        if loop.time() >= deadline:
+            raise AssertionError(
+                f"task did not reach the expected state within {timeout}s"
+            )
+
+        await asyncio.sleep(pause)
 
 
 @pytest.mark.asyncio
@@ -110,6 +138,82 @@ async def test_run_arg_path(async_authenticated_client, test_machine):
         output = await machine.run(remote_path)
 
         assert output
+
+
+@pytest.mark.asyncio
+async def test_run_task(async_authenticated_client, test_machine):
+    async with async_authenticated_client as client:
+        machine = await client.compute(test_machine)
+
+        task = await machine.run_task("echo hello")
+
+        assert isinstance(task, AsyncCommandTask)
+        assert task.id
+        assert task.status is None
+        assert task.result is None
+
+
+@pytest.mark.asyncio
+async def test_run_task_await(async_authenticated_client, test_machine):
+    async with async_authenticated_client as client:
+        machine = await client.compute(test_machine)
+
+        task = await machine.run_task("echo hello")
+        awaited = await task
+
+        assert awaited is task
+        assert task.status is TaskStatus.COMPLETED
+        assert task.result is not None
+        assert task.result.output == "hello\n"
+        assert task.result.error == ""
+
+
+@pytest.mark.asyncio
+async def test_run_task_update(async_authenticated_client, test_machine):
+    async with async_authenticated_client as client:
+        machine = await client.compute(test_machine)
+        task = await machine.run_task(_periodic_command())
+
+        updated = await _poll_task(
+            task,
+            lambda t: (
+                t.result is not None
+                and t.result.output is not None
+                and t.status is TaskStatus.COMPLETED
+            ),
+        )
+
+        assert updated is task
+
+
+@pytest.mark.asyncio
+async def test_run_task_cancel(async_authenticated_client, test_machine):
+    async with async_authenticated_client as client:
+        machine = await client.compute(test_machine)
+
+        task = await machine.run_task(_periodic_command())
+        await asyncio.sleep(2)
+        await task.cancel()
+
+        await _poll_task(task, lambda t: t.status == TaskStatus.CANCELLED, timeout=90)
+
+        assert task.status == TaskStatus.CANCELLED
+
+
+@pytest.mark.asyncio
+async def test_run_task_error(async_authenticated_client, test_machine):
+    async with async_authenticated_client as client:
+        machine = await client.compute(test_machine)
+
+        task = await machine.run_task(_failing_command())
+        await task
+
+        assert task.status is TaskStatus.COMPLETED
+        assert task.result is not None
+        assert task.result.error == "failing\n"
+        assert task.result.output == ""
+        assert task.result.exit_code == 1
+        assert task.result.status == "error"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Add support for running a command as a task. This exposes the ability to monitor and cancel a running task, rather than just waiting for it to complete.

I used specific class `AsyncCommandTask` and `AsyncCommandTaskResult` rather than `AsyncTask` and `AsyncTaskResult` as the current API defines the `result` field as a `str`, even though it has a JSON structure for running commands. I think this will future proof us a little, if tasks get use for different operation in the future and there are multiple formats for the `results` field. Thoughts?