### PR TITLE
Fix MkDocs build with current mkdocstrings

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,8 +37,6 @@ plugins:
         - https://docs.python.org/3/objects.inv
         options:
           docstring_style: sphinx
-          docstring_options:
-            ignore_init_summary: yes
           merge_init_into_class: yes
           show_submodules: no
 


### PR DESCRIPTION
Remove the explicit ignore_init_summary option from the mkdocstrings configuration. With current mkdocstrings-python and griffelib versions, explicit Sphinx options cause an unsupported warn_missing_types argument to be passed to the parser, breaking the documentation build.